### PR TITLE
button props type 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,16 @@ import { Button } from './components/Button';
 export function App() {
   return (
     <Div>
-      <Button type="container" color="accentPrimary">
+      <Button styledType="container" color="accentPrimary">
         <Login>로그인</Login>
       </Button>
-      <Button type="outline" color="neutralBorder">
+      <Button styledType="outline" color="neutralBorder">
         <Add>추가</Add>
       </Button>
-      <Button type="ghost">
+      <Button styledType="ghost">
         <SignUp>회원가입</SignUp>
       </Button>
-      <Button type="circle" color="accentPrimary">
+      <Button styledType="circle" color="accentPrimary">
         <Plus>+</Plus>
       </Button>
     </Div>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,22 +6,22 @@ type ButtonType = 'container' | 'outline' | 'ghost' | 'circle';
 
 type ButtonPropsWithColor = {
   children?: React.ReactNode;
-  type: Exclude<ButtonType, 'ghost'>;
+  styledType: Exclude<ButtonType, 'ghost'>;
   color: ColorType;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 type ButtonPropsGhost = {
   children?: React.ReactNode;
-  type: 'ghost';
+  styledType: 'ghost';
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 type ButtonProps = ButtonPropsWithColor | ButtonPropsGhost;
 
-export function Button({ children, type, color, ...rest }: ButtonProps) {
+export function Button({ children, styledType, color, ...rest }: ButtonProps) {
   return (
     <StyledButton
-      $type={type}
-      $color={type !== 'ghost' ? color : undefined}
+      $type={styledType}
+      $color={styledType !== 'ghost' ? color : undefined}
       {...rest}
     >
       {children}


### PR DESCRIPTION
## Description
- button props type 수정

## Key changes
- button의 type을 styledType으로 변경

## To reviewers
```ts
    interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
        disabled?: boolean | undefined;
        form?: string | undefined;
        formAction?:
            | string
            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS]
            | undefined;
        formEncType?: string | undefined;
        formMethod?: string | undefined;
        formNoValidate?: boolean | undefined;
        formTarget?: string | undefined;
        name?: string | undefined;
        styleType?: 'submit' | 'reset' | 'button' | undefined;
        value?: string | ReadonlyArray<string> | number | undefined;
    }
```
제 react 내부 ButtonHTMLAttributes의 속성중 type이 styleType으로 되어 있었습니다.

type으로 되어 있는걸로 알고 있었지만 확인했을 당시 이렇게 되어 있었습니다.
어떤 이유로 어떻게 변경되었는지 아니면 왜 이렇게 된 이유는 모르겠지만 원래 styleType이였나? 싶어서 그에 맞게 진행 했지만 
제 react 내 속성이 잘 못되었던 것이고 node_modules를 삭제하고 새로 다운로드 했더니 style로 돌아왔습니다.

그래서 그거에 맞게 type이라는 props 값을 styledType으로 변경합니다.

## Issue
- #12 
