### PR TITLE
badge component 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { styled } from 'styled-components';
+import { Badge } from './components/Badge';
 import { Button } from './components/Button';
-import { Icon } from './components/icon/Icon';
 import { Modal } from './components/Modal';
 import { TestModalContent } from './components/TestModalContent';
+import { Icon } from './components/icon/Icon';
 import elephantImg from '/elephant-bg.png';
 
 export function App() {
@@ -24,7 +25,7 @@ export function App() {
         <Button styledType="circle" color="accentPrimary">
           <Plus>+</Plus>
         </Button>
-        <IconWrapper>
+        <Wrapper>
           <Icon name="camera" color="accentPrimary" />
           <Icon name="check" color="accentSecondary" />
           <Icon name="chevronDown" color="systemWarning" />
@@ -36,7 +37,37 @@ export function App() {
           <Icon name="exclamationCircle" color="neutralBorderStrong" />
           <Icon name="heart" color="neutralOverlay" />
           <Icon name="home" color="neutralText" />
-        </IconWrapper>
+        </Wrapper>
+        <Wrapper>
+          <Badge
+            type="container"
+            size="S"
+            text="예약중"
+            fontColor="accentText"
+            badgeColor="accentSecondary"
+          />
+          <Badge
+            type="container"
+            size="M"
+            text="기타중고물품"
+            fontColor="accentText"
+            badgeColor="accentPrimary"
+          />
+          <Badge
+            type="outline"
+            size="M"
+            text="여성패션"
+            fontColor="accentTextWeak"
+            badgeColor="neutralBorder"
+          />
+          <Badge
+            type="container"
+            size="M"
+            text="1 / 2"
+            fontColor="neutralTextWeak"
+            badgeColor="neutralBackgroundBlur"
+          />
+        </Wrapper>
         <Button
           styledType="outline"
           color="neutralBorder"
@@ -66,7 +97,7 @@ const AppContainer = styled.div`
   align-items: center;
   background-color: ${({ theme }) => theme.color.neutralBackgroundWeak};
   background-image: url(${elephantImg});
-}`;
+`;
 
 const Layout = styled.div`
   width: 393px;
@@ -123,6 +154,9 @@ const Plus = styled.div`
   color: ${({ theme }) => theme.color.accentText};
 `;
 
-const IconWrapper = styled.div`
+const Wrapper = styled.div`
   display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
 `;

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,79 @@
+import { css, styled } from 'styled-components';
+import { ColorType } from '../styles/designSystem';
+
+type Size = 'S' | 'M';
+
+type BadgeType = 'container' | 'outline';
+
+type BadgeProps = {
+  fontColor: ColorType;
+  badgeColor: ColorType;
+  text: string;
+  size: Size;
+  type: BadgeType;
+};
+
+export function Badge({ fontColor, badgeColor, text, size, type }: BadgeProps) {
+  return (
+    <Div
+      $fontColor={fontColor}
+      $BadgeColor={badgeColor}
+      $size={size}
+      $type={type}
+    >
+      {text}
+    </Div>
+  );
+}
+
+const Div = styled.div<{
+  $fontColor: ColorType;
+  $BadgeColor: ColorType;
+  $size: Size;
+  $type: BadgeType;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ $size }) => sizeToCss($size)};
+
+  font: ${({ theme }) => theme.font.displayDefault12};
+  ${({ $type, $BadgeColor }) => typeToCss($type, $BadgeColor)};
+  color: ${({ theme, $fontColor: $color }) => theme.color[$color]};
+`;
+
+const sizeToCss = ($size: Size) => {
+  switch ($size) {
+    case 'S': {
+      return css`
+        padding: 3px 8px;
+        border-radius: 8px;
+      `;
+    }
+    case 'M': {
+      return css`
+        padding: 8px 16px;
+        border-radius: 50px;
+      `;
+    }
+    default:
+      return '';
+  }
+};
+
+const typeToCss = ($type: BadgeType, $BadgeColor: ColorType) => {
+  switch ($type) {
+    case 'container': {
+      return css`
+        background-color: ${({ theme }) => theme.color[$BadgeColor]};
+        border: none;
+      `;
+    }
+    case 'outline': {
+      return css`
+        border: ${({ theme }) => `1px solid ${theme.color[$BadgeColor]}`};
+      `;
+    }
+  }
+};

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -37,7 +37,6 @@ const Div = styled.div<{
   justify-content: center;
 
   ${({ $size }) => sizeToCss($size)};
-
   font: ${({ theme }) => theme.font.displayDefault12};
   ${({ $type, $BadgeColor }) => typeToCss($type, $BadgeColor)};
   color: ${({ theme, $fontColor: $color }) => theme.color[$color]};
@@ -75,5 +74,7 @@ const typeToCss = ($type: BadgeType, $BadgeColor: ColorType) => {
         border: ${({ theme }) => `1px solid ${theme.color[$BadgeColor]}`};
       `;
     }
+    default:
+      return '';
   }
 };


### PR DESCRIPTION
## Description
badge component 구현 했습니다.

## Key changes
![1](https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/048ed49f-755f-4233-b0fa-e9f883ff8c95)
- App.tsx에 badge 예시 4가지 추가했습니다.
- Badge props는 다음과 같습니다.
  ```ts

  type Size = 'S' | 'M';
  
  type BadgeType = 'container' | 'outline';
  
  type BadgeProps = {
    fontColor: ColorType;
    badgeColor: ColorType;
    text: string;
    size: Size;
    type: BadgeType;
  };

  ```
  - container의 경우 badgeColor는 background가 됩니다.
  - outline의 경우 badgeColor가 border의 색상이 됩니다.
  - size에 따라서 padding, border-radius의 값이 변경됩니다.

## Issue
- #14 
