### PR TITLE
setting library 및 리팩토링

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,7 +39,7 @@ module.exports = {
         ],
         alphabetize: {
           order: 'asc',
-          caseInsensitive: true,
+          caseInsensitive: false,
         },
         'newlines-between': 'never',
       },

--- a/generateIcons.js
+++ b/generateIcons.js
@@ -37,12 +37,17 @@ const iconNames = files
 const iconNamesWithSpaces = iconNames.map(name => `  ${name}`);
 const exportStatement = `export const icons = {\n${iconNamesWithSpaces.join(
   ',\n'
-)}, \n};`;
+)},\n};`;
 
 const types = `export type IconsType = keyof typeof icons;\n`;
-const content = `${imports}\n\n${exportStatement}\n\n${types}`;
 
-fs.writeFileSync(
-  path.resolve(__dirname, 'src/components/icon/icons.ts'),
-  content
-);
+const newContent = `${imports}\n\n${exportStatement}\n\n${types}`;
+const iconFilePath = path.resolve(__dirname, 'src/components/icon/icons.ts');
+
+const existingContent = fs.existsSync(iconFilePath)
+  ? fs.readFileSync(iconFilePath, 'utf-8')
+  : '';
+
+if (existingContent != newContent) {
+  fs.writeFileSync(iconFilePath, newContent);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "prettier": "^3.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.15.0",
         "styled-components": "^6.0.7"
       },
       "devDependencies": {
@@ -2481,6 +2482,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.8.0.tgz",
+      "integrity": "sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.0.3",
@@ -6341,6 +6350,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.15.0.tgz",
+      "integrity": "sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==",
+      "dependencies": {
+        "@remix-run/router": "1.8.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.15.0.tgz",
+      "integrity": "sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==",
+      "dependencies": {
+        "@remix-run/router": "1.8.0",
+        "react-router": "6.15.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/readable-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.15.0",
-        "styled-components": "^6.0.7"
+        "styled-components": "^6.0.7",
+        "zustand": "^4.4.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",
@@ -7523,6 +7524,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "second-hand",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^4.33.0",
         "@types/styled-components": "^5.1.26",
         "msw": "^1.2.3",
         "prettier": "^3.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-query": "^3.39.3",
         "styled-components": "^6.0.7"
       },
       "devDependencies": {
@@ -2713,6 +2713,41 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.33.0.tgz",
+      "integrity": "sha512-qYu73ptvnzRh6se2nyBIDHGBQvPY1XXl3yR769B7B6mIDD7s+EZhdlWHQ67JI6UOTFRaI7wupnTnwJ3gE0Mr/g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.33.0.tgz",
+      "integrity": "sha512-97nGbmDK0/m0B86BdiXzx3EW9RcDYKpnyL2+WwyuLHEgpfThYAnXFaMMmnTDuAO4bQJXEhflumIEUfKmP7ESGA==",
+      "dependencies": {
+        "@tanstack/query-core": "4.33.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -3341,14 +3376,6 @@
         }
       ]
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3385,21 +3412,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -3822,11 +3834,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5406,11 +5413,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5636,15 +5638,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5666,11 +5659,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -5830,14 +5818,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dependencies": {
-        "big-integer": "^1.6.16"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
@@ -5974,11 +5954,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6359,31 +6334,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -6498,11 +6448,6 @@
         "jsesc": "bin/jsesc"
       }
     },
-    "node_modules/remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6571,6 +6516,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7228,15 +7174,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -7273,6 +7210,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^4.33.0",
     "@types/styled-components": "^5.1.26",
     "msw": "^1.2.3",
     "prettier": "^3.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-query": "^3.39.3",
     "styled-components": "^6.0.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",
-    "styled-components": "^6.0.7"
+    "styled-components": "^6.0.7",
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "^3.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.15.0",
     "styled-components": "^6.0.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "typescript": "^5.1.6",
     "vite": "^4.4.5",
     "vite-plugin-svgr": "^3.2.0"
+  },
+  "msw": {
+    "workerDirectory": "public"
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,303 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (1.2.3).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '3d6b9f06410d179a7f7404d4bf4c3c70'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
+
+  event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the client).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.data
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [channel.port2])
+  })
+}
+
+function sleep(timeMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs)
+  })
+}
+
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { Badge } from './components/Badge';
 import { Button } from './components/Button';
@@ -9,6 +9,15 @@ import elephantImg from '/elephant-bg.png';
 
 export function App() {
   const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const test = async () => {
+      const res = await fetch('/api/test');
+      console.log(await res.json());
+    };
+
+    test();
+  });
 
   return (
     <AppContainer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,108 +1,52 @@
-import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { Link, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import { styled } from 'styled-components';
-import { Badge } from './components/Badge';
-import { Button } from './components/Button';
-import { Modal } from './components/Modal';
-import { TestModalContent } from './components/TestModalContent';
 import { Icon } from './components/icon/Icon';
+import { Auth } from './page/Auth';
+import { Main } from './page/Main';
+import { Test } from './page/Test';
 import elephantImg from '/elephant-bg.png';
 
 export function App() {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const { data, error, isLoading } = useQuery<string, Error>(
-    ['test'],
-    fetchTest
-  );
-
-  if (isLoading) console.log('loading');
-
-  if (error) console.log(error.message);
-
-  async function fetchTest() {
-    const res = await fetch('/api/test');
-
-    return res.json();
-  }
-
   return (
     <AppContainer>
       <Layout>
-        <div>{data}</div>
-        <Button styledType="container" color="accentPrimary">
-          <Login>로그인</Login>
-        </Button>
-        <Button styledType="outline" color="neutralBorder">
-          <Add>추가</Add>
-        </Button>
-        <Button styledType="ghost">
-          <SignUp>회원가입</SignUp>
-        </Button>
-        <Button styledType="circle" color="accentPrimary">
-          <Plus>+</Plus>
-        </Button>
-        <Wrapper>
-          <Icon name="camera" color="accentPrimary" />
-          <Icon name="check" color="accentSecondary" />
-          <Icon name="chevronDown" color="systemWarning" />
-          <Icon name="chevronLeft" color="accentTextWeak" />
-          <Icon name="chevronRight" color="neutralTextWeak" />
-          <Icon name="chevronUp" color="neutralTextStrong" />
-          <Icon name="circleXFilled" color="neutralBackgroundBold" />
-          <Icon name="dots" color="neutralOverlay" />
-          <Icon name="exclamationCircle" color="neutralBorderStrong" />
-          <Icon name="heart" color="neutralOverlay" />
-          <Icon name="home" color="neutralText" />
-        </Wrapper>
-        <Wrapper>
-          <Badge
-            type="container"
-            size="S"
-            text="예약중"
-            fontColor="accentText"
-            badgeColor="accentSecondary"
-          />
-          <Badge
-            type="container"
-            size="M"
-            text="기타중고물품"
-            fontColor="accentText"
-            badgeColor="accentPrimary"
-          />
-          <Badge
-            type="outline"
-            size="M"
-            text="여성패션"
-            fontColor="accentTextWeak"
-            badgeColor="neutralBorder"
-          />
-          <Badge
-            type="container"
-            size="M"
-            text="1 / 2"
-            fontColor="neutralTextWeak"
-            badgeColor="neutralBackgroundBlur"
-          />
-        </Wrapper>
-        <Button
-          styledType="outline"
-          color="neutralBorder"
-          onClick={() => setIsOpen(true)}
-        >
-          Open Modal
-        </Button>
-        {isOpen && (
-          <Modal
-            isOpen={isOpen}
-            onClose={() => setIsOpen(false)}
-            headline="동네 설정"
-          >
-            <TestModalContent />
-          </Modal>
-        )}
+        <Router>
+          <Routes>
+            <Route path="/" element={<Main />} />
+            <Route path="/test" element={<Test />} />
+            <Route path="/auth" element={<Auth />} />
+          </Routes>
+          <Footer />
+        </Router>
       </Layout>
     </AppContainer>
+  );
+}
+
+function Footer() {
+  return (
+    <FooterDiv>
+      <Tab to="/">
+        <Icon name="home" color="accentPrimary" />
+        <Label>홈화면</Label>
+      </Tab>
+      <Tab to="/">
+        <Icon name="news" color="accentSecondary" />
+        <Label>판매내역</Label>
+      </Tab>
+      <Tab to="/">
+        <Icon name="heart" color="systemWarning" />
+        <Label>관심상품</Label>
+      </Tab>
+      <Tab to="/test">
+        <Icon name="check" color="accentTextWeak" />
+        <Label>test</Label>
+      </Tab>
+      <Tab to="/auth">
+        <Icon name="userCircle" color="neutralTextWeak" />
+        <Label>내 계정</Label>
+      </Tab>
+    </FooterDiv>
   );
 }
 
@@ -131,49 +75,27 @@ const Layout = styled.div`
   background-color: ${({ theme }) => theme.color.accentText};
 `;
 
-const Login = styled.div`
-  width: 297px;
-  height: 24px;
+const FooterDiv = styled.div`
+  width: 100%;
+  height: 64px;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  font: ${({ theme }) => theme.font.availableStrong16};
-  color: ${({ theme }) => theme.color.systemBackgroundWeak};
+  padding: 8px 16px;
 `;
 
-const Add = styled.div`
-  width: 256px;
-  height: 24px;
+const Tab = styled(Link)`
+  width: 48px;
+  height: 48px;
   display: flex;
   justify-content: center;
   align-items: center;
-  font: ${({ theme }) => theme.font.availableStrong16};
-  color: ${({ theme }) => theme.color.accentTextWeak};
+  flex-direction: column;
+  cursor: pointer;
+  text-decoration: none;
 `;
 
-const SignUp = styled.div`
-  width: 45px;
-  height: 16px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font: ${({ theme }) => theme.font.availableStrong12};
-  color: ${({ theme }) => theme.color.neutralText};
-`;
-
-const Plus = styled.div`
-  width: 20px;
-  height: 20px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font: ${({ theme }) => theme.font.availableStrong16};
-  color: ${({ theme }) => theme.color.accentText};
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
+const Label = styled.span`
+  font: ${({ theme }) => theme.font.availableStrong10};
+  color: ${({ theme }) => theme.color.neutralTextWeak};
 `;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { styled } from 'styled-components';
 import { Badge } from './components/Badge';
 import { Button } from './components/Button';
@@ -10,18 +11,25 @@ import elephantImg from '/elephant-bg.png';
 export function App() {
   const [isOpen, setIsOpen] = useState(false);
 
-  useEffect(() => {
-    const test = async () => {
-      const res = await fetch('/api/test');
-      console.log(await res.json());
-    };
+  const { data, error, isLoading } = useQuery<string, Error>(
+    ['test'],
+    fetchTest
+  );
 
-    test();
-  });
+  if (isLoading) console.log('loading');
+
+  if (error) console.log(error.message);
+
+  async function fetchTest() {
+    const res = await fetch('/api/test');
+
+    return res.json();
+  }
 
   return (
     <AppContainer>
       <Layout>
+        <div>{data}</div>
         <Button styledType="container" color="accentPrimary">
           <Login>로그인</Login>
         </Button>

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { styled } from 'styled-components';
 import { ColorType, designSystem } from '../../styles/designSystem';
 import { IconsType, icons } from './icons';
 
@@ -29,8 +30,12 @@ export function Icon({ name, color }: IconProps) {
   }, [iconColor]);
 
   return (
-    <div ref={iconRef}>
+    <Div ref={iconRef}>
       <IconComponent />
-    </div>
+    </Div>
   );
 }
+
+const Div = styled.div`
+  display: flex;
+`;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ThemeProvider } from 'styled-components';
 import { App } from './App.tsx';
+import { worker } from './mocks/browser.ts';
 import { designSystem } from './styles/designSystem.ts';
 import './styles/index.css';
+
+if (process.env.NODE_ENV === 'development') {
+  worker.start({
+    onUnhandledRequest: 'bypass',
+  });
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ThemeProvider } from 'styled-components';
@@ -12,10 +13,14 @@ if (process.env.NODE_ENV === 'development') {
   });
 }
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider theme={designSystem}>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw';
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,7 @@
+import { rest } from 'msw';
+
+export const handlers = [
+  rest.get('/api/test', (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json('hello'));
+  }),
+];

--- a/src/page/Auth.tsx
+++ b/src/page/Auth.tsx
@@ -1,0 +1,14 @@
+import { styled } from 'styled-components';
+
+export function Auth() {
+  return <Div>로그인/회원가입/프로필</Div>;
+}
+
+const Div = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;

--- a/src/page/Main.tsx
+++ b/src/page/Main.tsx
@@ -1,7 +1,15 @@
 import { styled } from 'styled-components';
+import { countStore } from '../store';
 
 export function Main() {
-  return <Div>메인</Div>;
+  const { count } = countStore();
+
+  return (
+    <Div>
+      메인
+      <div>count : {count}</div>
+    </Div>
+  );
 }
 
 const Div = styled.div`

--- a/src/page/Main.tsx
+++ b/src/page/Main.tsx
@@ -1,0 +1,14 @@
+import { styled } from 'styled-components';
+
+export function Main() {
+  return <Div>메인</Div>;
+}
+
+const Div = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;

--- a/src/page/Test.tsx
+++ b/src/page/Test.tsx
@@ -1,0 +1,159 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+import { Badge } from '../components/Badge';
+import { Button } from '../components/Button';
+import { Modal } from '../components/Modal';
+import { TestModalContent } from '../components/TestModalContent';
+import { Icon } from '../components/icon/Icon';
+
+export function Test() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { data, error, isLoading } = useQuery<string, Error>(
+    ['test'],
+    fetchTest
+  );
+
+  if (isLoading) console.log('loading');
+
+  if (error) console.log(error.message);
+
+  async function fetchTest() {
+    const res = await fetch('/api/test');
+
+    return res.json();
+  }
+  return (
+    <Div>
+      <div>{data}</div>
+      <Button styledType="container" color="accentPrimary">
+        <Login>로그인</Login>
+      </Button>
+      <Button styledType="outline" color="neutralBorder">
+        <Add>추가</Add>
+      </Button>
+      <Button styledType="ghost">
+        <SignUp>회원가입</SignUp>
+      </Button>
+      <Button styledType="circle" color="accentPrimary">
+        <Plus>+</Plus>
+      </Button>
+      <Wrapper>
+        <Icon name="camera" color="accentPrimary" />
+        <Icon name="check" color="accentSecondary" />
+        <Icon name="chevronDown" color="systemWarning" />
+        <Icon name="chevronLeft" color="accentTextWeak" />
+        <Icon name="chevronRight" color="neutralTextWeak" />
+        <Icon name="chevronUp" color="neutralTextStrong" />
+        <Icon name="circleXFilled" color="neutralBackgroundBold" />
+        <Icon name="dots" color="neutralOverlay" />
+        <Icon name="exclamationCircle" color="neutralBorderStrong" />
+        <Icon name="heart" color="neutralOverlay" />
+        <Icon name="home" color="neutralText" />
+      </Wrapper>
+      <Wrapper>
+        <Badge
+          type="container"
+          size="S"
+          text="예약중"
+          fontColor="accentText"
+          badgeColor="accentSecondary"
+        />
+        <Badge
+          type="container"
+          size="M"
+          text="기타중고물품"
+          fontColor="accentText"
+          badgeColor="accentPrimary"
+        />
+        <Badge
+          type="outline"
+          size="M"
+          text="여성패션"
+          fontColor="accentTextWeak"
+          badgeColor="neutralBorder"
+        />
+        <Badge
+          type="container"
+          size="M"
+          text="1 / 2"
+          fontColor="neutralTextWeak"
+          badgeColor="neutralBackgroundBlur"
+        />
+      </Wrapper>
+      <Button
+        styledType="outline"
+        color="neutralBorder"
+        onClick={() => setIsOpen(true)}
+      >
+        Open Modal
+      </Button>
+      {isOpen && (
+        <Modal
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          headline="동네 설정"
+        >
+          <TestModalContent />
+        </Modal>
+      )}
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;
+
+const Login = styled.div`
+  width: 297px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font: ${({ theme }) => theme.font.availableStrong16};
+  color: ${({ theme }) => theme.color.systemBackgroundWeak};
+`;
+
+const Add = styled.div`
+  width: 256px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font: ${({ theme }) => theme.font.availableStrong16};
+  color: ${({ theme }) => theme.color.accentTextWeak};
+`;
+
+const SignUp = styled.div`
+  width: 45px;
+  height: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font: ${({ theme }) => theme.font.availableStrong12};
+  color: ${({ theme }) => theme.color.neutralText};
+`;
+
+const Plus = styled.div`
+  width: 20px;
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font: ${({ theme }) => theme.font.availableStrong16};
+  color: ${({ theme }) => theme.color.accentText};
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;

--- a/src/page/Test.tsx
+++ b/src/page/Test.tsx
@@ -6,8 +6,10 @@ import { Button } from '../components/Button';
 import { Modal } from '../components/Modal';
 import { TestModalContent } from '../components/TestModalContent';
 import { Icon } from '../components/icon/Icon';
+import { countStore } from '../store';
 
 export function Test() {
+  const { count, increment } = countStore();
   const [isOpen, setIsOpen] = useState(false);
 
   const { data, error, isLoading } = useQuery<string, Error>(
@@ -26,7 +28,13 @@ export function Test() {
   }
   return (
     <Div>
-      <div>{data}</div>
+      <ResDiv>react query res : {data}</ResDiv>
+      <TestZustand>
+        <div>count :{count}</div>
+        <Button styledType="ghost" color="accentPrimary" onClick={increment}>
+          <Icon name="plus" color="neutralTextStrong" />
+        </Button>
+      </TestZustand>
       <Button styledType="container" color="accentPrimary">
         <Login>로그인</Login>
       </Button>
@@ -109,6 +117,7 @@ const Div = styled.div`
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  gap: 10px;
 `;
 
 const Login = styled.div`
@@ -156,4 +165,16 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   gap: 10px;
+`;
+
+const ResDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const TestZustand = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+type State = {
+  count: number;
+  increment: () => void;
+};
+
+export const countStore = create<State>(set => ({
+  count: 0,
+  increment: () => set(state => ({ count: state.count + 1 })),
+}));


### PR DESCRIPTION
## Description
- msw 설정
- react query 설정
- 라우트 설정
- zustand 설정
- icon 컴포넌트 display 추가
- generateIcons.js 리팩토링


## Key changes
### 메인 페이지
![1](https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/f65e7b03-c216-4a81-962d-9143fc050d19)

### test 페이지
![2](https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/3eb70d55-a463-48a7-8527-6c787453c502)

### 인증 관련, 프로필 페이지
![3](https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/a03cbc13-e762-4f81-84d0-d81a89a95547)


- 다음 route path 추가 했습니다.
  - `/`, `/test`, `/auth`
  - 홈화면, 판매내역, 관심상품 아이콘으로 `/` 으로 이동 가능합니다.
  - test 아이콘으로 /test 으로 이동 가능합니다.
  - 내 프로필 아이콘으로 /auth로 이동 가능합니다.
- test 페이지 에서 다음 기능 확인 가능합니다
  - react query로 msw에 get요청해서 출력 된 hello 볼 수 있습니다.
  - zustand로 관리하는 count state가 있습니다.
  - +버튼으로 증가하는 거 확인 가능하며 main 페이지에 있는 count도 zustand로 관리되고 있는 같은 state입니다.

## Issue
- #19