### PR TITLE
product item UI 및 util 함수 추가

### DIFF
--- a/src/components/ProductItem.tsx
+++ b/src/components/ProductItem.tsx
@@ -63,13 +63,15 @@ export function ProductItem({
           {locationName}・{getElapsedSince(createdAt)}
         </LocationAndTimestamp>
         <StateAndPrice>
-          <Badge
-            type="container"
-            size="S"
-            text={statusName}
-            fontColor="accentText"
-            badgeColor="accentSecondary"
-          />
+          {statusName !== '' && (
+            <Badge
+              type="container"
+              size="S"
+              text={statusName}
+              fontColor="accentText"
+              badgeColor="accentSecondary"
+            />
+          )}
           <Price>{setPrice(price)}</Price>
         </StateAndPrice>
         <History>

--- a/src/components/ProductItem.tsx
+++ b/src/components/ProductItem.tsx
@@ -1,0 +1,164 @@
+import { styled } from 'styled-components';
+import { useAuthStore } from '../stores/authStore';
+import { addCommasToNumber } from '../utils/addCommasToNumber';
+import { getElapsedSince } from '../utils/getElapsedSince';
+import { Badge } from './Badge';
+import { Icon } from './icon/Icon';
+
+type ItemProps = {
+  seller: string;
+  id: number;
+  title: string;
+  locationName: string;
+  createdAt: Date;
+  statusName: string;
+  price: number | null;
+  countData: {
+    chat: number;
+    favorite: number;
+  };
+  thumbnailUrl: string;
+};
+
+export function ProductItem({
+  seller,
+  id,
+  title,
+  locationName,
+  createdAt,
+  statusName,
+  price,
+  countData,
+  thumbnailUrl,
+}: ItemProps) {
+  const { chat, favorite } = countData;
+  const { userName } = useAuthStore();
+
+  const setPrice = (price: number | null) => {
+    switch (price) {
+      case null:
+        return '가격 미정';
+      case 0:
+        return '나눔';
+      default:
+        return `${addCommasToNumber(price)}원`;
+    }
+  };
+
+  return (
+    <Div
+      onClick={() => {
+        console.log(id);
+      }}
+    >
+      <Thumbnail src={thumbnailUrl} />
+      <Information>
+        <Title>
+          <span>{title}</span>
+          {userName === seller && (
+            <Icon name="dots" color="neutralTextStrong" />
+          )}
+        </Title>
+        <LocationAndTimestamp>
+          {locationName}・{getElapsedSince(createdAt)}
+        </LocationAndTimestamp>
+        <StateAndPrice>
+          <Badge
+            type="container"
+            size="S"
+            text={statusName}
+            fontColor="accentText"
+            badgeColor="accentSecondary"
+          />
+          <Price>{setPrice(price)}</Price>
+        </StateAndPrice>
+        <History>
+          {chat > 0 && (
+            <CountWrapper>
+              <Icon name="message" color="neutralTextWeak" />
+              {chat}
+            </CountWrapper>
+          )}
+          {favorite > 0 && (
+            <CountWrapper>
+              <Icon name="heart" color="neutralTextWeak" />
+              {chat}
+            </CountWrapper>
+          )}
+        </History>
+      </Information>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  height: 152px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 0;
+  border-bottom: ${({ theme }) => `0.8px solid ${theme.color.neutralBorder}`};
+`;
+
+const Thumbnail = styled.img`
+  width: 120px;
+  height: 120px;
+  border-radius: 8px;
+  border: ${({ theme }) => `1px solid ${theme.color.neutralBorder}`};
+`;
+
+const Information = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  flex: 1;
+  gap: 4px;
+
+  & > div {
+    width: 100%;
+    display: flex;
+  }
+`;
+
+const Title = styled.div`
+  font: ${({ theme }) => theme.font.displayDefault16};
+  color: ${({ theme }) => theme.color.neutralText};
+
+  & span {
+    flex: 1;
+  }
+`;
+
+const LocationAndTimestamp = styled.div`
+  font: ${({ theme }) => theme.font.displayDefault12};
+  color: ${({ theme }) => theme.color.neutralTextWeak};
+`;
+
+const StateAndPrice = styled.div`
+  gap: 4px;
+`;
+
+const Price = styled.div`
+  font: ${({ theme }) => theme.font.displayStrong16};
+  color: ${({ theme }) => theme.color.neutralTextStrong};
+`;
+
+const History = styled.div`
+  display: flex;
+  justify-content: right;
+  align-items: end;
+  flex: 1;
+  gap: 4px;
+`;
+
+const CountWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font: ${({ theme }) => theme.font.displayDefault12};
+  color: ${({ theme }) => theme.color.neutralTextWeak};
+`;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,9 +1,11 @@
 import { rest } from 'msw';
 import { authHandlers } from './authHandlers';
+import { mainHandlers } from './mainHandlers';
 
 export const handlers = [
   rest.get('/api/test', (_, res, ctx) => {
     return res(ctx.status(200), ctx.json('hello'));
   }),
   ...authHandlers,
+  ...mainHandlers,
 ];

--- a/src/mocks/mainHandlers.ts
+++ b/src/mocks/mainHandlers.ts
@@ -1,0 +1,22 @@
+import { rest } from 'msw';
+
+export const mainHandlers = [
+  rest.get('/api/item', (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(item));
+  }),
+];
+
+const item = {
+  id: 1,
+  title: '글제목',
+  locationName: '역삼 1동',
+  createdAt: new Date('2023-08-28T23:04:33'),
+  statusName: '예약중',
+  price: 10000,
+  countData: {
+    chat: 10,
+    favorite: 10,
+  },
+  thumbnailUrl:
+    'https://www.ikea.com/kr/ko/images/products/alex-storage-unit-white__1209817_pe909458_s5.jpg?f=xl',
+};

--- a/src/page/Test.tsx
+++ b/src/page/Test.tsx
@@ -6,6 +6,7 @@ import { Button } from '../components/Button';
 import { Modal } from '../components/Modal';
 import { TestModalContent } from '../components/TestModalContent';
 import { Icon } from '../components/icon/Icon';
+import { ProductItem } from '../components/productItem';
 import { countStore, useNameStore } from '../store';
 
 export function Test() {
@@ -29,6 +30,17 @@ export function Test() {
   }
   return (
     <Div>
+      <ProductItem
+        seller="testUser"
+        id={1}
+        thumbnailUrl="https://www.ikea.com/kr/ko/images/products/alex-storage-unit-white__1209817_pe909458_s5.jpg?f=xl"
+        title="글제목"
+        locationName="역삼 1동"
+        createdAt={new Date()}
+        statusName="예약 중"
+        price={null}
+        countData={{ chat: 10, favorite: 2 }}
+      />
       <ResDiv>react query res : {data}</ResDiv>
       <TestZustand>
         <div>count :{count}</div>

--- a/src/page/Test.tsx
+++ b/src/page/Test.tsx
@@ -9,39 +9,29 @@ import { Icon } from '../components/icon/Icon';
 import { ProductItem } from '../components/productItem';
 import { countStore, useNameStore } from '../store';
 
+const fetchItem = async () => {
+  const res = await fetch('/api/item');
+
+  return res.json();
+};
+
 export function Test() {
   const { count, increment } = countStore();
   const { firstName, updateFirstName } = useNameStore();
   const [isOpen, setIsOpen] = useState(false);
+  const { data: itemData, isLoading, isError } = useQuery(['item'], fetchItem);
 
-  const { data, error, isLoading } = useQuery<string, Error>(
-    ['test'],
-    fetchTest
-  );
-
-  if (isLoading) console.log('loading');
-
-  if (error) console.log(error.message);
-
-  async function fetchTest() {
-    const res = await fetch('/api/test');
-
-    return res.json();
+  if (isLoading) {
+    return <div>Loading...</div>;
   }
+
+  if (isError) {
+    return <div>Error occurred</div>;
+  }
+
   return (
     <Div>
-      <ProductItem
-        seller="testUser"
-        id={1}
-        thumbnailUrl="https://www.ikea.com/kr/ko/images/products/alex-storage-unit-white__1209817_pe909458_s5.jpg?f=xl"
-        title="글제목"
-        locationName="역삼 1동"
-        createdAt={new Date()}
-        statusName="예약 중"
-        price={null}
-        countData={{ chat: 10, favorite: 2 }}
-      />
-      <ResDiv>react query res : {data}</ResDiv>
+      <ProductItem {...itemData} />
       <TestZustand>
         <div>count :{count}</div>
         <Button styledType="ghost" color="accentPrimary" onClick={increment}>
@@ -187,12 +177,6 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   gap: 10px;
-`;
-
-const ResDiv = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
 `;
 
 const TestZustand = styled.div`

--- a/src/utils/addCommasToNumber.ts
+++ b/src/utils/addCommasToNumber.ts
@@ -1,0 +1,3 @@
+export const addCommasToNumber = (number: number): string => {
+  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};

--- a/src/utils/getElapsedSince.ts
+++ b/src/utils/getElapsedSince.ts
@@ -1,0 +1,22 @@
+export const getElapsedSince = (dateObj: Date) => {
+  const MS = 1000;
+  const MINUTE = 60 * MS;
+  const HOUR = 60 * MINUTE;
+  const DAY = 24 * HOUR;
+  const MONTH = 31 * DAY;
+
+  const now = Date.now();
+  const diff = now - new Date(dateObj).getTime();
+
+  if (diff < MINUTE) {
+    return '방금';
+  } else if (diff < HOUR) {
+    return Math.floor(diff / MINUTE) + '분 전';
+  } else if (diff < DAY) {
+    return Math.floor(diff / HOUR) + '시간 전';
+  } else if (diff < MONTH) {
+    return Math.floor(diff / DAY) + '일 전';
+  } else {
+    return Math.floor(diff / MONTH) + '달 전';
+  }
+};


### PR DESCRIPTION
## Description
- product item  UI 구현
- addCommasToNumber 구현
- getElapsedSince 구현

## Key changes
<img width="432" alt="스크린샷 2023-08-28 오후 11 11 19" src="https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/da187ee4-dc52-4613-8ed0-c74c6e86380d">

- item data를 받아 우선 랜더링하도록 구현 했습니다.
  - 타입은 다음과 같습니다.
  ```ts
  type ItemProps = {
    seller: string;
    id: number;
    title: string;
    locationName: string;
    createdAt: Date;
    statusName: string;
    price: number | null;
    countData: {
      chat: number;
      favorite: number;
    };
    thumbnailUrl: string;
  };
  ```
- addCommasToNumber, getElapsedSince는 지난 프로젝트에서 사용한 util 함수 가져왔습니다.
- 지금 현재 기능은 해당 컴포넌트를 클릭하면 item id를 console.log만 찍습니다.
- 우측 상단에 [ ... ]은 본인이 작성한 판매글에만 표시해야 해서 seller라는 값을 api에 추가했습니다.
  - 그 sellor와 저장되어 있는 본인(zustand에 있는 유저 정보)의 name과 같으면 본인이 작성한 판매글이라 판단하고 [ ... ] 을 랜더링 합니다.
- badge는 statusName이 빈문자가 아닐 경우만 랜더링 합니다.
  - 우선 badge의 색상은 mint 색상으로 고정이지만 판매 완료, 예약 등에 따라서 색을 구분해도 좋을 것 같습니다.

## Issue
- #29 
