### PR TITLE
refactor #32 : api 관리 폴더로 분할

### DIFF
--- a/src/api/endPoint.ts
+++ b/src/api/endPoint.ts
@@ -1,0 +1,1 @@
+export const API_ENDPOINT = { ITEM: '/api/item' };

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -1,0 +1,7 @@
+import { API_ENDPOINT } from './endPoint';
+
+export const getItem = async () => {
+  const res = await fetch(API_ENDPOINT.ITEM);
+
+  return res.json();
+};

--- a/src/page/Test.tsx
+++ b/src/page/Test.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { styled } from 'styled-components';
+import { getItem } from '../api/fetcher';
 import { Badge } from '../components/Badge';
 import { Button } from '../components/Button';
 import { Modal } from '../components/Modal';
@@ -9,17 +10,11 @@ import { TestModalContent } from '../components/TestModalContent';
 import { Icon } from '../components/icon/Icon';
 import { countStore, useNameStore } from '../store';
 
-const fetchItem = async () => {
-  const res = await fetch('/api/item');
-
-  return res.json();
-};
-
 export function Test() {
   const { count, increment } = countStore();
   const { firstName, updateFirstName } = useNameStore();
   const [isOpen, setIsOpen] = useState(false);
-  const { data: itemData, isLoading, isError } = useQuery(['item'], fetchItem);
+  const { data: itemData, isLoading, isError } = useQuery(['item'], getItem);
 
   if (isLoading) {
     return <div>Loading...</div>;


### PR DESCRIPTION
## Description
- api 관리 폴더로 분할 했습니다
## Key changes
```ts
// endPoint.ts
export const API_ENDPOINT = { ITEM: '/api/item' };
```
- api endpoint를 관리하는 파일을 따로 놓았습니다.

``` ts
// fetcher.ts 
import { API_ENDPOINT } from './endPoint';

export const getItem = async () => {
  const res = await fetch(API_ENDPOINT.ITEM);

  return res.json();
};
```
- fetcher 파일도 따로 놓았습니다.
- fetch할 api가 20개가 넘는데 모두 이곳에서 관리하는 방법과 사용처에 따라서 또 분리하는 방법도 생각중입니다.
  - ex) authFetcher.ts, mainFetcher.ts 등등
  - 근데 20개 정도면 하나의 파일로도 괜찮을 것 같기도 한데 퓨즈 의견 궁금합니다.

## Issue
- #32 
