### PR TITLE
로그인/회원가입 요청 API 명세서랑 다른 부분 수정

### DIFF
--- a/src/api/endPoint.ts
+++ b/src/api/endPoint.ts
@@ -1,4 +1,6 @@
 export const API_ENDPOINT = {
+  LOGIN: '/api/login',
+  SIGNUP: '/api/signup',
   ITEMS: '/api/items',
   USER_LOCATION: '/api/users/locations',
   CATEGORIES: '/api/categories',

--- a/src/mocks/authHandlers.ts
+++ b/src/mocks/authHandlers.ts
@@ -1,10 +1,11 @@
 import { rest } from 'msw';
+import { API_ENDPOINT } from '../api/endPoint';
 
 export const authHandlers = [
-  rest.post('/api/login', (req, res, ctx) => {
+  rest.post(API_ENDPOINT.LOGIN, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(user));
   }),
-  rest.post('/api/signup', (req, res, ctx) => {
+  rest.post(API_ENDPOINT.SIGNUP, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json('201'));
   }),
 ];

--- a/src/mocks/authHandlers.ts
+++ b/src/mocks/authHandlers.ts
@@ -2,13 +2,9 @@ import { rest } from 'msw';
 
 export const authHandlers = [
   rest.post('/api/login', (req, res, ctx) => {
-    console.log(req.body);
-
     return res(ctx.status(200), ctx.json(user));
   }),
   rest.post('/api/signup', (req, res, ctx) => {
-    console.log(req.body);
-
     return res(ctx.status(200), ctx.json('201'));
   }),
 ];

--- a/src/page/auth/LoginPage.tsx
+++ b/src/page/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, useState } from 'react';
 import { styled } from 'styled-components';
 import axios from '../../api/axios';
+import { API_ENDPOINT } from '../../api/endPoint';
 import { Button } from '../../components/Button';
 import { Icon } from '../../components/icon/Icon';
 import { useAuthStore } from '../../stores/useAuthStore';
@@ -37,7 +38,10 @@ export function LoginPage() {
   };
 
   const submit = async () => {
-    const res = await axios.post('/api/login', { username: id, password });
+    const res = await axios.post(API_ENDPOINT.LOGIN, {
+      username: id,
+      password,
+    });
 
     if (res.statusText === 'OK') {
       const data = res.data;

--- a/src/page/auth/LoginPage.tsx
+++ b/src/page/auth/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useState } from 'react';
 import { styled } from 'styled-components';
+import axios from '../../api/axios';
 import { Button } from '../../components/Button';
 import { Icon } from '../../components/icon/Icon';
 import { useAuthStore } from '../../stores/useAuthStore';
@@ -36,16 +37,10 @@ export function LoginPage() {
   };
 
   const submit = async () => {
-    const res = await fetch('/api/login', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ id, password }),
-    });
+    const res = await axios.post('/api/login', { username: id, password });
 
-    if (res.ok) {
-      const data = await res.json();
+    if (res.statusText === 'OK') {
+      const data = res.data;
       const { accessToken, ...userInfo } = data;
 
       setAccessToken(accessToken);

--- a/src/page/auth/SignUpPanel.tsx
+++ b/src/page/auth/SignUpPanel.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { styled } from 'styled-components';
 import axios from '../../api/axios';
+import { API_ENDPOINT } from '../../api/endPoint';
 import { Button } from '../../components/Button';
 import { Icon } from '../../components/icon/Icon';
 import { useScreenConfigStore } from '../../stores/useScreenConfigStore';
@@ -104,7 +105,7 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
       formData.append('profileImageFile', file);
     }
 
-    const res = await axios.post('/api/signup', formData, {
+    const res = await axios.post(API_ENDPOINT.SIGNUP, formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },

--- a/src/page/auth/SignUpPanel.tsx
+++ b/src/page/auth/SignUpPanel.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { styled } from 'styled-components';
+import axios from '../../api/axios';
 import { Button } from '../../components/Button';
 import { Icon } from '../../components/icon/Icon';
 import { useScreenConfigStore } from '../../stores/useScreenConfigStore';
@@ -86,22 +87,31 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
 
   const submit = async () => {
     const formData = new FormData();
-    formData.append('id', id);
-    formData.append('password', password);
-    formData.append('locationName', location);
+    const signupData = {
+      username: id,
+      nickName: 'JayJay', // TODO : 닉네임 입력 받아 추가
+      password: password,
+      locationName: location,
+    };
+
+    formData.append(
+      'signupData',
+      new Blob([JSON.stringify(signupData)], { type: 'application/json' }),
+      'signupData'
+    );
 
     if (file) {
       formData.append('profileImageFile', file);
     }
 
-    const res = await fetch('/api/signup', {
-      method: 'POST',
-      body: formData,
+    const res = await axios.post('/api/signup', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
     });
 
-    if (res.ok) {
-      const data = await res.json();
-      console.log('Response:', data);
+    if (res.statusText === 'OK') {
+      console.log('Response:', res.data);
       closePanel();
     }
   };


### PR DESCRIPTION
## Description
- 로그인/회원가입 요청 API 명세서랑 다른 부분을 수정하였습니다.

## Key changes
- signup 시 multipart/form-data 형식으로 요청 body에 프로필 이미지 파일 함께 나머지 데이터들을 signupData 라는 객체로 감싸서 보내야하는데, `FormData`는 string이나 Blob 타입의 데이터만 넣을 수 있더라구요. 그래서 우선 아래와 같이 수정했는데 백엔드 쪽에서 정상적으로 받아서 활용할 수 있는지 모르겠네요. 🤔
```tsx
const formData = new FormData();
    const signupData = {
      username: id,
      nickName: 'JayJay', // TODO : 닉네임 입력 받아 추가
      password: password,
      locationName: location,
    };

    formData.append(
      'signupData',
      new Blob([JSON.stringify(signupData)], { type: 'application/json' }),
      'signupData'
    );
   ...
```

## To reviewers

## Issue
- #49  
