### PR TITLE
동네검색 모달화면 무한스크롤 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "prettier": "^3.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.5.2",
         "react-router-dom": "^6.15.0",
         "styled-components": "^6.0.7",
         "zustand": "^4.4.1"
@@ -6519,6 +6520,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "predev": "node generateIcons.js",
-    "dev": "vite --host 0.0.0.0 --port 5173",
+    "dev": "vite",
     "prebuild": "node generateIcons.js",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepreview": "node generateIcons.js",
     "preview": "vite preview",
     "prestart": "node generateIcons.js",
-    "start": "cross-env NODE_ENV=production vite"
+    "start": "cross-env NODE_ENV=production vite --host 0.0.0.0"
   },
   "dependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prettier": "^3.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.5.2",
     "react-router-dom": "^6.15.0",
     "styled-components": "^6.0.7",
     "zustand": "^4.4.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "predev": "node generateIcons.js",
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0 --port 5173",
     "prebuild": "node generateIcons.js",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -12,8 +12,10 @@ export const getUserLocations = async (): Promise<UserLocationData> => {
   return res.data;
 };
 
-export const getLocationData = async () => {
-  const res = await axios.get(API_ENDPOINT.LOCATION_DATA);
+export const getLocationData = async ({ pageParam = 0 }) => {
+  const res = await axios.get(
+    `${API_ENDPOINT.LOCATION_DATA}?cursor=${pageParam}`
+  );
   return res.data;
 };
 

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -12,9 +12,15 @@ export const getUserLocations = async (): Promise<UserLocationData> => {
   return res.data;
 };
 
-export const getLocationData = async ({ pageParam = 0 }) => {
+export const getLocationData = async ({
+  pageParam,
+  searchParam,
+}: {
+  pageParam: number;
+  searchParam: string;
+}) => {
   const res = await axios.get(
-    `${API_ENDPOINT.LOCATION_DATA}?cursor=${pageParam}`
+    `${API_ENDPOINT.LOCATION_DATA}?cursor=${pageParam}&search=${searchParam}`
   );
   return res.data;
 };

--- a/src/components/locations/AddLocation.tsx
+++ b/src/components/locations/AddLocation.tsx
@@ -1,13 +1,9 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { styled } from 'styled-components';
 import { getLocationData } from '../../api/fetcher';
-import {
-  useAddUserLocation,
-  useGetLocationData,
-} from '../../queries/useLocationQuery';
+import { useAddUserLocation } from '../../queries/useLocationQuery';
 import { Error } from '../Error';
-import { Loader } from '../Loader';
 
 type AddLocationProps = {
   rightPosition: number;
@@ -36,11 +32,29 @@ export function AddLocation({
     hasNextPage, // boolean
     isFetchingNextPage, // boolean
     data,
-    status,
     error,
   } = useInfiniteQuery<PostData>(['/locations'], getLocationData, {
     getNextPageParam: lastPage => lastPage.nextId ?? undefined,
   });
+
+  const intObserver = useRef<IntersectionObserver>();
+  const lastPostRef = useCallback(
+    (locationItem: HTMLLIElement) => {
+      if (isFetchingNextPage) return;
+      if (intObserver.current) intObserver.current.disconnect();
+
+      intObserver.current = new IntersectionObserver(posts => {
+        if (posts[0].isIntersecting && hasNextPage) {
+          console.log('마지막 요소 도달');
+          fetchNextPage();
+        }
+      });
+
+      if (locationItem) intObserver.current.observe(locationItem);
+    },
+    [isFetchingNextPage, fetchNextPage, hasNextPage]
+  );
+
   const addMutation = useAddUserLocation();
 
   useEffect(() => {
@@ -48,6 +62,7 @@ export function AddLocation({
   }, []);
 
   const onClickLocationItem = (locationName: string) => {
+    console.log(intObserver.current);
     addMutation.mutate(locationName);
     hideSearchPanel();
   };
@@ -64,22 +79,29 @@ export function AddLocation({
       onTransitionEnd={onTransitionEndHandler}
     >
       <SearchBar placeholder="동명(읍, 면)으로 검색 (ex. 서초동)" />
-      {isFetchingNextPage ? (
-        <Loader />
-      ) : (
-        <Content>
-          {data?.pages.map(page => {
-            return page.locations.map(location => (
+      <Content>
+        {data?.pages.map(page => {
+          return page.locations.map((location, index) =>
+            index === page.locations.length - 1 ? (
+              <LocationItem
+                ref={lastPostRef}
+                key={location.id}
+                onClick={() => onClickLocationItem(location.name)}
+              >
+                {location.name}
+              </LocationItem>
+            ) : (
               <LocationItem
                 key={location.id}
                 onClick={() => onClickLocationItem(location.name)}
               >
                 {location.name}
               </LocationItem>
-            ));
-          })}
-        </Content>
-      )}
+            )
+          );
+        })}
+        {isFetchingNextPage && <LoadingMessage>Loading...</LoadingMessage>}
+      </Content>
     </Container>
   );
 }
@@ -90,6 +112,7 @@ const Container = styled.div<{ $rightPosition: number }>`
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 8px;
   padding: 0 24px 16px;
   position: absolute;
   top: 0;
@@ -106,6 +129,7 @@ const SearchBar = styled.input`
   border-radius: 8px;
   font: ${({ theme }) => theme.font.displayDefault16};
   background-color: ${({ theme }) => theme.color.neutralBackgroundBold};
+  outline-color: ${({ theme }) => theme.color.accentPrimary};
 `;
 
 const Content = styled.ul`
@@ -117,10 +141,13 @@ const Content = styled.ul`
   overflow-y: scroll;
 
   &::-webkit-scrollbar {
-    display: none;
+    width: 4px;
   }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+
+  &::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => theme.color.neutralBorderStrong};
+    border-radius: 10px;
+  }
 `;
 
 const LocationItem = styled.li`
@@ -136,4 +163,9 @@ const LocationItem = styled.li`
   &:hover {
     background-color: ${({ theme }) => theme.color.neutralBackgroundBold};
   }
+`;
+
+const LoadingMessage = styled.li`
+  padding: 16px 0px 15px;
+  margin: 0 auto;
 `;

--- a/src/components/locations/AddLocation.tsx
+++ b/src/components/locations/AddLocation.tsx
@@ -58,24 +58,18 @@ export function AddLocation({
       ) : (
         <Content>
           {data?.pages.map(page => {
-            return page.locations.map((location, index) =>
-              index === page.locations.length - 1 ? (
+            return page.locations.map((location, index) => {
+              const isLastItem = index === page.locations.length - 1;
+              return (
                 <LocationItem
-                  ref={lastItemRef}
+                  ref={isLastItem ? lastItemRef : null}
                   key={location.id}
                   onClick={() => onClickLocationItem(location.name)}
                 >
                   {location.name}
                 </LocationItem>
-              ) : (
-                <LocationItem
-                  key={location.id}
-                  onClick={() => onClickLocationItem(location.name)}
-                >
-                  {location.name}
-                </LocationItem>
-              )
-            );
+              );
+            });
           })}
           {isFetchingNextPage && <LoadingMessage>Loading...</LoadingMessage>}
         </Content>

--- a/src/components/locations/AddLocation.tsx
+++ b/src/components/locations/AddLocation.tsx
@@ -1,6 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useCallback } from 'react';
 import { styled } from 'styled-components';
+import { API_ENDPOINT } from '../../api/endPoint';
 import { getLocationData } from '../../api/fetcher';
 import { useAddUserLocation } from '../../queries/useLocationQuery';
 import { Error } from '../Error';
@@ -26,16 +27,16 @@ export function AddLocation({
   closeSearchPanel,
   hideSearchPanel,
 }: AddLocationProps) {
-  // const { data, isLoading, isError } = useGetLocationData();
-  const {
-    fetchNextPage, //function
-    hasNextPage, // boolean
-    isFetchingNextPage, // boolean
-    data,
-    error,
-  } = useInfiniteQuery<PostData>(['/locations'], getLocationData, {
-    getNextPageParam: lastPage => lastPage.nextId ?? undefined,
-  });
+  // TODO: SeachBar 인풋에 입력받은 단어를 searchParam으로 넘겨주기
+  const { fetchNextPage, hasNextPage, isFetchingNextPage, data, error } =
+    useInfiniteQuery<PostData>(
+      [API_ENDPOINT.LOCATION_DATA],
+      ({ pageParam = 0 }) =>
+        getLocationData({ pageParam, searchParam: '역삼' }),
+      {
+        getNextPageParam: lastPage => lastPage.nextId ?? undefined,
+      }
+    );
 
   const intObserver = useRef<IntersectionObserver>();
   const lastPostRef = useCallback(

--- a/src/mocks/authHandlers.ts
+++ b/src/mocks/authHandlers.ts
@@ -2,10 +2,10 @@ import { rest } from 'msw';
 import { API_ENDPOINT } from '../api/endPoint';
 
 export const authHandlers = [
-  rest.post(API_ENDPOINT.LOGIN, (req, res, ctx) => {
+  rest.post(API_ENDPOINT.LOGIN, (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(user));
   }),
-  rest.post(API_ENDPOINT.SIGNUP, (req, res, ctx) => {
+  rest.post(API_ENDPOINT.SIGNUP, (_, res, ctx) => {
     return res(ctx.status(200), ctx.json('201'));
   }),
 ];

--- a/src/mocks/locationHandlers.ts
+++ b/src/mocks/locationHandlers.ts
@@ -1,6 +1,10 @@
 import { rest } from 'msw';
 import { API_ENDPOINT } from '../api/endPoint';
 
+type PostUserLocationRequestBody = {
+  name: string;
+};
+
 export const locationHandlers = [
   rest.get(API_ENDPOINT.USER_LOCATION, (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(userLocations));
@@ -25,15 +29,23 @@ export const locationHandlers = [
     return res(ctx.status(200), ctx.json({ locations: data, nextId }));
   }),
 
-  rest.post(API_ENDPOINT.USER_LOCATION, (req, res, ctx) => {
-    userLocations = {
-      locations: [
-        ...userLocations.locations,
-        { id: 3, name: req.body?.name.split(' ').at(-1), isSelected: false },
-      ],
-    };
-    return res(ctx.status(200), ctx.json({ message: '동네 추가 성공' }));
-  }),
+  rest.post<PostUserLocationRequestBody>(
+    API_ENDPOINT.USER_LOCATION,
+    (req, res, ctx) => {
+      const { name } = req.body;
+      userLocations = {
+        locations: [
+          ...userLocations.locations,
+          {
+            id: 3,
+            name: name.split(' ').at(-1) ?? '',
+            isSelected: false,
+          },
+        ],
+      };
+      return res(ctx.status(200), ctx.json({ message: '동네 추가 성공' }));
+    }
+  ),
 
   rest.patch(`${API_ENDPOINT.USER_LOCATION}/:id`, (req, res, ctx) => {
     const { id } = req.params;

--- a/src/mocks/locationHandlers.ts
+++ b/src/mocks/locationHandlers.ts
@@ -19,9 +19,9 @@ export const locationHandlers = [
         };
       });
 
+    // 지역 데이터는 최대 45개까지만 제공
     const nextId = cursor < 30 ? data[data.length - 1].id + 1 : null;
 
-    // setTimeout(() => res.json({ data, nextId }), 1000);
     return res(ctx.status(200), ctx.json({ locations: data, nextId }));
   }),
 

--- a/src/mocks/locationHandlers.ts
+++ b/src/mocks/locationHandlers.ts
@@ -6,8 +6,23 @@ export const locationHandlers = [
     return res(ctx.status(200), ctx.json(userLocations));
   }),
 
-  rest.get(API_ENDPOINT.LOCATION_DATA, (_, res, ctx) => {
-    return res(ctx.status(200), ctx.json(locationData));
+  rest.get(API_ENDPOINT.LOCATION_DATA, (req, res, ctx) => {
+    const cursor = parseInt(req.url.searchParams.get('cursor') ?? '0');
+    const pageSize = 15;
+
+    const data = Array(pageSize)
+      .fill(0)
+      .map((_, i) => {
+        return {
+          id: i + cursor,
+          name: 'Location No.' + (i + cursor),
+        };
+      });
+
+    const nextId = cursor < 30 ? data[data.length - 1].id + 1 : null;
+
+    // setTimeout(() => res.json({ data, nextId }), 1000);
+    return res(ctx.status(200), ctx.json({ locations: data, nextId }));
   }),
 
   rest.post(API_ENDPOINT.USER_LOCATION, (req, res, ctx) => {

--- a/src/mocks/locationHandlers.ts
+++ b/src/mocks/locationHandlers.ts
@@ -24,9 +24,9 @@ export const locationHandlers = [
       });
 
     // 지역 데이터는 최대 45개까지만 제공
-    const nextId = cursor < 30 ? data[data.length - 1].id + 1 : null;
+    const nextCursor = cursor < 30 ? data[data.length - 1].id + 1 : null;
 
-    return res(ctx.status(200), ctx.json({ locations: data, nextId }));
+    return res(ctx.status(200), ctx.json({ locations: data, nextCursor }));
   }),
 
   rest.post<PostUserLocationRequestBody>(

--- a/src/mocks/locationHandlers.ts
+++ b/src/mocks/locationHandlers.ts
@@ -7,7 +7,7 @@ export const locationHandlers = [
   }),
 
   rest.get(API_ENDPOINT.LOCATION_DATA, (req, res, ctx) => {
-    const cursor = parseInt(req.url.searchParams.get('cursor') ?? '0');
+    const cursor = parseInt(req.url.searchParams.get('cursor')!);
     const pageSize = 15;
 
     const data = Array(pageSize)
@@ -15,7 +15,7 @@ export const locationHandlers = [
       .map((_, i) => {
         return {
           id: i + cursor,
-          name: 'Location No.' + (i + cursor),
+          name: `${i + cursor}. ` + DummyLocation[(i + cursor) % 15].item,
         };
       });
 
@@ -74,7 +74,7 @@ let userLocations = {
   ],
 };
 
-const locationData = [
+const DummyLocation = [
   {
     id: 1,
     item: '서울특별시 송파구 가락동',
@@ -134,25 +134,5 @@ const locationData = [
   {
     id: 15,
     item: '서울특별시 은평구 가좌로',
-  },
-  {
-    id: 16,
-    item: '서울특별시 서대문구 가좌로',
-  },
-  {
-    id: 17,
-    item: '서울특별시 종로구 가회동',
-  },
-  {
-    id: 18,
-    item: '서울특별시 서대문구 간호대로',
-  },
-  {
-    id: 19,
-    item: '서울특별시 용산구 갈월동',
-  },
-  {
-    id: 20,
-    item: '서울특별시 은평구 갈현동',
   },
 ];

--- a/src/queries/useLocationQuery.ts
+++ b/src/queries/useLocationQuery.ts
@@ -1,13 +1,30 @@
-import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
+import {
+  useQuery,
+  useQueryClient,
+  useMutation,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
 import {
   getUserLocations,
+  getLocationData,
   addUserLocation,
   deleteUserLocation,
   selectUserLocation,
 } from '../api/fetcher';
-import { UserLocationData } from '../types';
+import { UserLocationData, LocationResultData } from '../types';
 
 const USER_LOCATION_QUERY_KEY = '/users/locations';
+const LOCATION_QUERY_KEY = '/locations';
+
+export const useGetLocationResult = (searchParam: string) => {
+  return useInfiniteQuery<LocationResultData>(
+    [LOCATION_QUERY_KEY],
+    ({ pageParam = 0 }) => getLocationData({ pageParam, searchParam }),
+    {
+      getNextPageParam: lastPage => lastPage.nextId ?? undefined,
+    }
+  );
+};
 
 export const useGetUserLocation = () => {
   return useQuery<UserLocationData>(
@@ -20,7 +37,7 @@ export const useAddUserLocation = () => {
   const queryClient = useQueryClient();
   return useMutation(addUserLocation, {
     onSuccess: () => {
-      queryClient.invalidateQueries(['/users/locations']);
+      queryClient.invalidateQueries([USER_LOCATION_QUERY_KEY]);
     },
   });
 };

--- a/src/queries/useLocationQuery.ts
+++ b/src/queries/useLocationQuery.ts
@@ -21,7 +21,7 @@ export const useGetLocationResult = (searchParam: string) => {
     [LOCATION_QUERY_KEY],
     ({ pageParam = 0 }) => getLocationData({ pageParam, searchParam }),
     {
-      getNextPageParam: lastPage => lastPage.nextId ?? undefined,
+      getNextPageParam: lastPage => lastPage.nextCursor ?? undefined,
     }
   );
 };

--- a/src/queries/useLocationQuery.ts
+++ b/src/queries/useLocationQuery.ts
@@ -18,9 +18,9 @@ export const useGetUserLocation = () => {
   );
 };
 
-// export const useGetLocationData = () => {
-//   return useQuery<LocationData>([LOCATION_QUERY_KEY], getLocationData);
-// };
+export const useGetLocationData = () => {
+  return useQuery<LocationData>([LOCATION_QUERY_KEY], getLocationData);
+};
 
 export const useAddUserLocation = () => {
   const queryClient = useQueryClient();

--- a/src/queries/useLocationQuery.ts
+++ b/src/queries/useLocationQuery.ts
@@ -18,9 +18,9 @@ export const useGetUserLocation = () => {
   );
 };
 
-export const useGetLocationData = () => {
-  return useQuery<LocationData>([LOCATION_QUERY_KEY], getLocationData);
-};
+// export const useGetLocationData = () => {
+//   return useQuery<LocationData>([LOCATION_QUERY_KEY], getLocationData);
+// };
 
 export const useAddUserLocation = () => {
   const queryClient = useQueryClient();

--- a/src/queries/useLocationQuery.ts
+++ b/src/queries/useLocationQuery.ts
@@ -4,22 +4,16 @@ import {
   addUserLocation,
   deleteUserLocation,
   selectUserLocation,
-  getLocationData,
 } from '../api/fetcher';
-import { LocationData, UserLocationData } from '../types';
+import { UserLocationData } from '../types';
 
 const USER_LOCATION_QUERY_KEY = '/users/locations';
-const LOCATION_QUERY_KEY = '/locations';
 
 export const useGetUserLocation = () => {
   return useQuery<UserLocationData>(
     [USER_LOCATION_QUERY_KEY],
     getUserLocations
   );
-};
-
-export const useGetLocationData = () => {
-  return useQuery<LocationData>([LOCATION_QUERY_KEY], getLocationData);
 };
 
 export const useAddUserLocation = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,5 +16,5 @@ export type LocationResultData = {
     id: number;
     name: string;
   }[];
-  nextId: number | null;
+  nextCursor: number | null;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,11 @@ export type LocationData = {
   id: number;
   item: string;
 }[];
+
+export type LocationResultData = {
+  locations: {
+    id: number;
+    name: string;
+  }[];
+  nextId: number | null;
+};


### PR DESCRIPTION
## Description
- 지역 검색 모달 화면에서 지역리스트를 불러올 때 무한스크롤 기능을 적용했습니다.

## Key changes
![화면 기록 2023-09-04 오후 3 18 03](https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/76121068/66af1bae-9e89-4b28-b9f2-5bb1ccfe0677)

- `locationHandlers`에 요청마다 15개의 지역 데이터를 제공하는 함수 추가했습니다. 요청 url에서 쿼리 파라미터로 받은 `cursor`값을 이용해 단순히 1씩 더해가며 id를 생성하는 mock data입니다. (현재는 45개까지 제한을 걸어둔 상태입니다.)
- 우선 searchParam도 인자로 받는데 이 부분은 인풋창 작업하면서 추후 구현할 예정입니다.

- 리액트 쿼리의 useInfiniteQuery() 훅을 이용해서 무한 스크롤 기능 구현했습니다. 서버의 response로 오는 `nextId` 값을 이용해 nextPageParam을 구하고, 이를 다음 cursor 값으로 이용해 새로운 요청을 보냅니다.

- intersectionObserver API로 처음에 구현을 했는데 이를 커스텀 훅으로 따로 분리하는 과정이 좀 복잡해져서, `react-intersection-observer`라는 라이브러리의 `useInView` 훅으로 변경하게 되었습니다.

  사용 예시)
    ```tsx
    import React from 'react';
    import { useInView } from 'react-intersection-observer';
    
    const Component = () => {
      const { ref, inView } = useInView();
    
      // ref는 관찰하고자 하는 컴포넌트의 ref로 전달
      // 등록된 컴포넌트가 화면 상에 나타나면 (isIntersecting이 true일 때) inView 값이 true로 변한다.
      return (
        <div ref={ref}>
          <h2>{`Header inside viewport ${inView}.`}</h2>
        </div>
      );
    };
    ```
- 지역 리스트 맨 마지막에 오는 `LocationItem`컴포넌트를 관찰하도록 설정했습니다.
- 어제 배포 테스트 해보면서 package.json에 dev와 start script 부분에 `--host 0.0.0.0` 옵션을 추가했는데 이 부분이 계속 남겨둬야 할지 지워도 상관없을지 고민되네요 🤔

## To reviewers
우선 리액트 쿼리 공식문서에 있는 구현 예제부분을 많이 참고하면서 구현을 했습니다.
https://tanstack.com/query/v4/docs/react/examples/react/load-more-infinite-scroll

## Issue
- #53 