### PR TITLE
배포를 위한 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 import { Layout } from './components/Layout';
 import { Test } from './page/Test';
 import { MyAccount } from './page/auth/MyAccount';
+import { OAuthLoading } from './page/auth/OAuthLoading';
 import { Home } from './page/home/Home';
 import { useScreenConfigStore } from './stores/useScreenConfigStore';
 import elephantImg from '/elephant-bg.png';
@@ -26,6 +27,11 @@ export function App() {
           <Route path="/" element={<Home />} />
           <Route path="/test" element={<Test />} />
           <Route path="/myAccount" element={<MyAccount />} />
+          <Route
+            path="/oauth2/authorization/github"
+            element={<OAuthLoading />}
+          />
+          <Route path="/login/oauth2/code/github" element={<OAuthLoading />} />
         </Route>
       </Routes>
     </AppContainer>

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-const BASE_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_URL;
+export const BASE_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_URL;
 
 export const fetcher = axios.create({
   baseURL: BASE_URL,

--- a/src/api/endPoint.ts
+++ b/src/api/endPoint.ts
@@ -1,6 +1,6 @@
 export const API_ENDPOINT = {
   LOGIN: '/api/login',
-  SIGNUP: '/api/signup',
+  SIGNUP: '/api/users',
   ITEMS: '/api/items',
   USER_LOCATION: '/api/users/locations',
   LOCATION_DATA: '/api/locations',

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,9 +1,10 @@
-import { styled, keyframes } from 'styled-components';
+import { keyframes, styled } from 'styled-components';
 
-export function Loader() {
+export function Loader({ text }: { text?: string }) {
   return (
     <Wrapper>
       <Indicator />
+      {text && <div>{text}</div>}
     </Wrapper>
   );
 }
@@ -21,7 +22,9 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
   position: absolute;
+  gap: 16px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/src/page/auth/LoginPage.tsx
+++ b/src/page/auth/LoginPage.tsx
@@ -45,7 +45,7 @@ export function LoginPage() {
   };
 
   const OAuthLogin = async () => {
-    window.location.assign(`${BASE_URL}/api/oauth2/authorization/github`);
+    window.location.assign(`${BASE_URL}/oauth2/authorization/github`);
   };
 
   return (

--- a/src/page/auth/LoginPage.tsx
+++ b/src/page/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, useState } from 'react';
 import { styled } from 'styled-components';
 import { useLogin } from '../../api/authFetcher';
+import { BASE_URL } from '../../api/axios';
 import { Button } from '../../components/button/Button';
 import { Icon } from '../../components/icon/Icon';
 import { AuthInput } from './AuthInput';
@@ -43,15 +44,20 @@ export function LoginPage() {
     console.log(res);
   };
 
+  const OAuthLogin = () => {
+    window.location.assign(`${BASE_URL}/oauth2/authorization/github`);
+  };
+
   return (
     <>
       {isOpenPanel && <SignUpPanel closePanel={closePanel} />}
       <Div>
         <Body>
           <Button
+            style={{ height: 42 }}
             styledType="outline"
             color="neutralTextStrong"
-            onClick={submit}
+            onClick={OAuthLogin}
           >
             <Icon name="octocat" color="accentText" />
             GitHub 로그인

--- a/src/page/auth/LoginPage.tsx
+++ b/src/page/auth/LoginPage.tsx
@@ -44,8 +44,8 @@ export function LoginPage() {
     console.log(res);
   };
 
-  const OAuthLogin = () => {
-    window.location.assign(`${BASE_URL}/oauth2/authorization/github`);
+  const OAuthLogin = async () => {
+    window.location.assign(`${BASE_URL}/api/oauth2/authorization/github`);
   };
 
   return (

--- a/src/page/auth/OAuthLoading.tsx
+++ b/src/page/auth/OAuthLoading.tsx
@@ -20,8 +20,7 @@ export function OAuthLoading() {
       <Header title="내 계정" />
       <LoginPage />
       <Body>
-        <Loader />
-        <div>Github로 로그인 중</div>
+        <Loader text="Github로 로그인 중" />
       </Body>
     </>
   );

--- a/src/page/auth/OAuthLoading.tsx
+++ b/src/page/auth/OAuthLoading.tsx
@@ -1,9 +1,20 @@
 import { styled } from 'styled-components';
+import { BASE_URL } from '../../api/axios';
 import { Header } from '../../components/Header';
 import { Loader } from '../../components/Loader';
 import { LoginPage } from './LoginPage';
 
 export function OAuthLoading() {
+  const pathAndQuery = window.location.pathname + window.location.search;
+
+  const login = async () => {
+    const url = `${BASE_URL}:8080${pathAndQuery}`;
+    const res = await fetch(url);
+
+    console.log(await res.json());
+  };
+
+  login();
   return (
     <>
       <Header title="내 계정" />

--- a/src/page/auth/OAuthLoading.tsx
+++ b/src/page/auth/OAuthLoading.tsx
@@ -1,0 +1,31 @@
+import { styled } from 'styled-components';
+import { Header } from '../../components/Header';
+import { Loader } from '../../components/Loader';
+import { LoginPage } from './LoginPage';
+
+export function OAuthLoading() {
+  return (
+    <>
+      <Header title="내 계정" />
+      <LoginPage />
+      <Body>
+        <Loader />
+        <div>Github로 로그인 중</div>
+      </Body>
+    </>
+  );
+}
+
+const Body = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 20px;
+  position: absolute;
+  z-index: 10;
+  background: ${({ theme }) => theme.color.neutralBackgroundBlur};
+  backdrop-filter: blur(2px);
+`;


### PR DESCRIPTION
## Description
주로 로그인, oauth 관련 리팩토링 진행 했습니다.

## Key changes
<img width="377" alt="스크린샷 2023-09-08 오후 7 31 47" src="https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/6b6bee08-dfa3-4651-898d-d4cc5cb06e42">

- oauth로 로그인 후 인가 코드를 받는 페이지 구현 했습니다.
- github 로그인 페이지로 연결은 되고 있지만 로그인 후 인가 코드를 서버로 전달하지 못하고 있습니다.
- 회원가입 api end point 수정 했습니다.
- 위 예시 처럼 Loader에 텍스트를 함께 보여주는 경우가 있는데 이 부분 text를 props로 받도록 수정했습니다.

## Issue
- #68 
