### PR TITLE
판매 내역 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { Layout } from './components/Layout';
+import { SellHistory } from './page/SellHistory';
 import { Test } from './page/Test';
 import { MyAccount } from './page/auth/MyAccount';
 import { OAuthLoading } from './page/auth/OAuthLoading';
@@ -27,6 +28,7 @@ export function App() {
           <Route path="/" element={<Home />} />
           <Route path="/test" element={<Test />} />
           <Route path="/myAccount" element={<MyAccount />} />
+          <Route path="/sellHistory" element={<SellHistory />} />
           <Route
             path="/oauth2/authorization/github"
             element={<OAuthLoading />}

--- a/src/api/SellHistoryFetcher.ts
+++ b/src/api/SellHistoryFetcher.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { BASE_URL } from './axios';
+import { API_ENDPOINT } from './endPoint';
+
+export const getSellHistory = async ({
+  cursor,
+  isSold,
+  nickname,
+}: {
+  cursor?: number;
+  isSold?: boolean;
+  nickname: string;
+}) => {
+  const url = new URL(BASE_URL + API_ENDPOINT.SELL_HISTORY(nickname));
+
+  cursor !== undefined && url.searchParams.append('cursor', String(cursor));
+  isSold !== undefined && url.searchParams.append('isSold', String(isSold));
+
+  const res = await axios.get(url.toString());
+
+  return res.data;
+};

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,10 @@
 import axios from 'axios';
-export const BASE_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_URL;
+
+const currentPort = window.location.port;
+
+export const BASE_URL = import.meta.env.DEV
+  ? `http://localhost:${currentPort}`
+  : import.meta.env.VITE_API_URL;
 
 export const fetcher = axios.create({
   baseURL: BASE_URL,

--- a/src/api/endPoint.ts
+++ b/src/api/endPoint.ts
@@ -1,6 +1,6 @@
 export const API_ENDPOINT = {
   LOGIN: '/api/login',
-  SIGNUP: '/api/signup',
+  SIGNUP: '/api/users',
   ITEMS: '/api/items',
   USER_LOCATION: '/api/users/locations',
   LOCATION_DATA: '/api/locations',

--- a/src/api/endPoint.ts
+++ b/src/api/endPoint.ts
@@ -1,8 +1,11 @@
 export const API_ENDPOINT = {
   LOGIN: '/api/login',
-  SIGNUP: '/api/users',
+  SIGNUP: '/api/signup',
   ITEMS: '/api/items',
   USER_LOCATION: '/api/users/locations',
   LOCATION_DATA: '/api/locations',
   CATEGORIES: '/api/categories',
+  SELL_HISTORY: (nickname: string) => {
+    return `/api/users/${nickname}/items`;
+  },
 };

--- a/src/api/mainFetcher.ts
+++ b/src/api/mainFetcher.ts
@@ -1,4 +1,4 @@
-import { fetcher } from './axios';
+import { BASE_URL, fetcher } from './axios';
 import { API_ENDPOINT } from './endPoint';
 
 // useInfiniteQuery 제대로 동작 안하는 오류 해결 필요
@@ -9,22 +9,15 @@ export const getItems = async ({
   pageParam: number;
   categoryId: number | null;
 }) => {
-  // URLsearchParams랑 append 써보기
-  // 아니면 남세 스타일
-  //   '?' + [
-  //     ...(cursorParam ? [`cursor=${cursorParam}`] : []),
-  //     ...(categoryId ? [`categoryId=${categoryId}`] : []),
-  // ].join('&');
-  const queryString =
-    cursorParam && categoryId
-      ? `?cursor=${cursorParam}&categoryId=${categoryId}`
-      : cursorParam
-      ? `?cursor=${cursorParam}`
-      : categoryId
-      ? `?categoryId=${categoryId}`
-      : '';
+  const url = new URL(BASE_URL + API_ENDPOINT.ITEMS);
 
-  const res = await fetcher.get(`${API_ENDPOINT.ITEMS}${queryString}`);
+  cursorParam !== undefined &&
+    url.searchParams.append('cursor', String(cursorParam));
+  categoryId !== undefined &&
+    url.searchParams.append('categoryId', String(categoryId));
+
+  const res = await fetcher.get(url.toString());
+
   return res.data;
 };
 

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -3,23 +3,35 @@ import { ColorType } from '../styles/designSystem';
 
 type Size = 'S' | 'M';
 
-type BadgeType = 'container' | 'outline';
+export type BadgeType = 'container' | 'outline';
 
-type BadgeProps = {
+export type BadgeProps = {
   fontColor: ColorType;
   badgeColor: ColorType;
   text: string;
   size: Size;
   type: BadgeType;
+  onClick?: () => void;
 };
 
-export function Badge({ fontColor, badgeColor, text, size, type }: BadgeProps) {
+export function Badge({
+  fontColor,
+  badgeColor,
+  text,
+  size,
+  type,
+  onClick,
+}: BadgeProps) {
+  const isClickable = !!onClick;
+
   return (
     <Div
       $fontColor={fontColor}
       $BadgeColor={badgeColor}
       $size={size}
       $type={type}
+      $isClickable={isClickable}
+      onClick={onClick}
     >
       {text}
     </Div>
@@ -31,6 +43,7 @@ const Div = styled.div<{
   $BadgeColor: ColorType;
   $size: Size;
   $type: BadgeType;
+  $isClickable: boolean;
 }>`
   display: flex;
   align-items: center;
@@ -40,6 +53,7 @@ const Div = styled.div<{
   font: ${({ theme }) => theme.font.displayDefault12};
   ${({ $type, $BadgeColor }) => typeToCss($type, $BadgeColor)};
   color: ${({ theme, $fontColor: $color }) => theme.color[$color]};
+  ${({ $isClickable }) => $isClickable && 'cursor: pointer;'}
 `;
 
 const sizeToCss = ($size: Size) => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ export function Footer() {
         <Icon name="home" color="accentPrimary" />
         <Label>홈화면</Label>
       </Tab>
-      <Tab to="/">
+      <Tab to="/sellHistory">
         <Icon name="news" color="accentSecondary" />
         <Label>판매내역</Label>
       </Tab>

--- a/src/mocks/faker.ts
+++ b/src/mocks/faker.ts
@@ -30,3 +30,26 @@ export const fakeItems = () => {
 
   return items;
 };
+
+export const fakeSellItems = () => {
+  const items = [];
+  for (let i = 2; i <= 20; i++) {
+    const item = {
+      id: i,
+      title: faker.lorem.words(3),
+      locationName: '역삼 1동',
+      createdAt: faker.date.past(),
+      statusName: faker.helpers.arrayElement(['예약중', '판매중', '판매완료']),
+      price: i * 1000,
+      countData: {
+        chat: faker.number.int({ min: 1, max: 100 }),
+        favorite: faker.number.int({ min: 1, max: 100 }),
+      },
+      thumbnailUrl: faker.helpers.arrayElement(thumbnailList),
+      isSeller: true,
+    };
+    items.push(item);
+  }
+
+  return items;
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,9 @@
 import { authHandlers } from './authHandlers';
+import { itemsHandlers } from './itemsHandlers';
 import { locationHandlers } from './locationHandlers';
-import { mainHandlers } from './mainHandlers';
 
-export const handlers = [...authHandlers, ...locationHandlers, ...mainHandlers];
+export const handlers = [
+  ...authHandlers,
+  ...locationHandlers,
+  ...itemsHandlers,
+];

--- a/src/mocks/itemsHandlers.ts
+++ b/src/mocks/itemsHandlers.ts
@@ -73,7 +73,6 @@ const sellHistoryData = {
       },
       thumbnailUrl:
         'https://www.ikea.com/kr/ko/images/products/alex-storage-unit-white__1209817_pe909458_s5.jpg?f=xl',
-      isSeller: true,
     },
     ...fakeSellItems(),
   ],

--- a/src/mocks/itemsHandlers.ts
+++ b/src/mocks/itemsHandlers.ts
@@ -1,15 +1,19 @@
 import { rest } from 'msw';
 import { API_ENDPOINT } from '../api/endPoint';
 import { ItemData } from '../types';
-import { fakeItems } from './faker';
+import { fakeItems, fakeSellItems } from './faker';
 
-export const mainHandlers = [
+export const itemsHandlers = [
   rest.get(API_ENDPOINT.ITEMS, (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(homeData));
   }),
 
   rest.get(API_ENDPOINT.CATEGORIES, (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(categoryData));
+  }),
+
+  rest.get(API_ENDPOINT.SELL_HISTORY('testUser'), (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(sellHistoryData));
   }),
 ];
 
@@ -35,6 +39,29 @@ const homeData: ItemData = {
     ...fakeItems(),
   ],
   nextCursor: 1,
+};
+
+const sellHistoryData = {
+  items: [
+    {
+      id: 1,
+      title: '글제목',
+      locationName: '역삼 1동',
+      createdAt: new Date('2023-08-28T23:04:33'),
+      statusName: '예약중',
+      price: 10000,
+      countData: {
+        chat: 10,
+        favorite: 10,
+      },
+      thumbnailUrl:
+        'https://www.ikea.com/kr/ko/images/products/alex-storage-unit-white__1209817_pe909458_s5.jpg?f=xl',
+      isSeller: true,
+    },
+    ...fakeSellItems(),
+  ],
+  nextCursor: 1,
+  hasNext: false,
 };
 
 const categoryData = {

--- a/src/mocks/itemsHandlers.ts
+++ b/src/mocks/itemsHandlers.ts
@@ -12,8 +12,25 @@ export const itemsHandlers = [
     return res(ctx.status(200), ctx.json(categoryData));
   }),
 
-  rest.get(API_ENDPOINT.SELL_HISTORY('testUser'), (_, res, ctx) => {
-    return res(ctx.status(200), ctx.json(sellHistoryData));
+  rest.get(API_ENDPOINT.SELL_HISTORY('testUser'), (req, res, ctx) => {
+    const isSoldParams = req.url.searchParams.get('isSold');
+    // const cursorParams = req.url.searchParams.get('cursor');
+
+    if (!isSoldParams) {
+      return res(ctx.status(200), ctx.json(sellHistoryData));
+    }
+
+    const isSold = isSoldParams === 'true';
+    const newItems = sellHistoryData.items.filter(item => {
+      return isSold
+        ? item.statusName === '판매중'
+        : item.statusName === '판매완료';
+    });
+
+    return res(
+      ctx.status(200),
+      ctx.json({ ...sellHistoryData, items: newItems })
+    );
   }),
 ];
 
@@ -61,7 +78,6 @@ const sellHistoryData = {
     ...fakeSellItems(),
   ],
   nextCursor: 1,
-  hasNext: false,
 };
 
 const categoryData = {

--- a/src/page/SellHistory.tsx
+++ b/src/page/SellHistory.tsx
@@ -1,0 +1,116 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+import { getSellHistory } from '../api/SellHistoryFetcher';
+import { Badge, BadgeProps } from '../components/Badge';
+import { Header } from '../components/Header';
+import { ProductItem } from '../components/ProductItem';
+import { useAuthStore } from '../stores/useAuthStore';
+import { ItemProps } from '../types';
+
+type HistoryData = {
+  items: ItemProps[];
+  nextCursor: number;
+  hasNext: boolean;
+};
+
+export function SellHistory() {
+  const { nickname } = useAuthStore();
+  const [isSold, setIsSold] = useState<boolean>();
+  const { data: historyData } = useQuery<HistoryData, Error>(
+    ['history', isSold],
+    () => getSellHistory({ nickname, isSold })
+  );
+
+  const setBadgeOption = (text: string, status: boolean | undefined) => {
+    const isSelected = isSold === status;
+
+    const options: BadgeProps = isSelected
+      ? {
+          text,
+          badgeColor: 'accentPrimary',
+          fontColor: 'accentText',
+          size: 'M',
+          type: 'container',
+          onClick: () => setIsSold(status),
+        }
+      : {
+          text,
+          badgeColor: 'neutralBorder',
+          fontColor: 'accentTextWeak',
+          size: 'M',
+          type: 'outline',
+          onClick: () => setIsSold(status),
+        };
+
+    return options;
+  };
+
+  return (
+    <Div>
+      <TopBar>
+        <Header title="판매 내역" />
+        <Tabs>
+          <Badge {...setBadgeOption('전체', undefined)} />
+          <Badge {...setBadgeOption('판매 중', true)} />
+          <Badge {...setBadgeOption('판매 완료', false)} />
+        </Tabs>
+      </TopBar>
+
+      <Body>
+        {historyData ? (
+          <>
+            {historyData.items.map((item: ItemProps) => {
+              return <ProductItem key={item.id} {...item} />;
+            })}
+          </>
+        ) : (
+          <div></div>
+        )}
+      </Body>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
+const TopBar = styled.div`
+  width: 100%;
+  position: absolute;
+  z-index: 1;
+`;
+
+const Body = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 0 16px;
+  margin-top: 95px;
+`;
+
+const Tabs = styled.div`
+  width: 100%;
+  height: 48px;
+  display: flex;
+  position: relative;
+  gap: 4px;
+  padding: 8px 16px;
+  margin-top: 56px;
+  border-bottom: ${({ theme }) => `0.8px solid ${theme.color.neutralBorder}`};
+  background-color: ${({ theme }) => theme.color.accentText};
+  backdrop-filter: ${({ theme }) => theme.backdropFilter.blur};
+`;

--- a/src/page/SellHistory.tsx
+++ b/src/page/SellHistory.tsx
@@ -6,10 +6,10 @@ import { Badge, BadgeProps } from '../components/Badge';
 import { Header } from '../components/Header';
 import { ProductItem } from '../components/ProductItem';
 import { useAuthStore } from '../stores/useAuthStore';
-import { ItemProps } from '../types';
+import { ItemBaseType } from '../types';
 
 type HistoryData = {
-  items: ItemProps[];
+  items: ItemBaseType[];
   nextCursor: number;
 };
 
@@ -51,8 +51,8 @@ export function SellHistory() {
       <Body>
         {historyData ? (
           <>
-            {historyData.items.map((item: ItemProps) => {
-              return <ProductItem key={item.id} {...item} />;
+            {historyData.items.map((item: ItemBaseType) => {
+              return <ProductItem key={item.id} {...item} isSeller={true} />;
             })}
           </>
         ) : (

--- a/src/page/SellHistory.tsx
+++ b/src/page/SellHistory.tsx
@@ -11,7 +11,6 @@ import { ItemProps } from '../types';
 type HistoryData = {
   items: ItemProps[];
   nextCursor: number;
-  hasNext: boolean;
 };
 
 export function SellHistory() {
@@ -22,26 +21,18 @@ export function SellHistory() {
     () => getSellHistory({ nickname, isSold })
   );
 
+  // 무한 스크롤 구현
   const setBadgeOption = (text: string, status: boolean | undefined) => {
     const isSelected = isSold === status;
 
-    const options: BadgeProps = isSelected
-      ? {
-          text,
-          badgeColor: 'accentPrimary',
-          fontColor: 'accentText',
-          size: 'M',
-          type: 'container',
-          onClick: () => setIsSold(status),
-        }
-      : {
-          text,
-          badgeColor: 'neutralBorder',
-          fontColor: 'accentTextWeak',
-          size: 'M',
-          type: 'outline',
-          onClick: () => setIsSold(status),
-        };
+    const options: BadgeProps = {
+      text,
+      badgeColor: isSelected ? 'accentPrimary' : 'neutralBorder',
+      fontColor: isSelected ? 'accentText' : 'accentTextWeak',
+      size: 'M',
+      type: isSelected ? 'container' : 'outline',
+      onClick: () => setIsSold(status),
+    };
 
     return options;
   };

--- a/src/page/SellHistory.tsx
+++ b/src/page/SellHistory.tsx
@@ -3,7 +3,9 @@ import { useState } from 'react';
 import { styled } from 'styled-components';
 import { getSellHistory } from '../api/SellHistoryFetcher';
 import { Badge, BadgeProps } from '../components/Badge';
+import { Error } from '../components/Error';
 import { Header } from '../components/Header';
+import { Loader } from '../components/Loader';
 import { ProductItem } from '../components/ProductItem';
 import { useAuthStore } from '../stores/useAuthStore';
 import { ItemBaseType } from '../types';
@@ -16,9 +18,12 @@ type HistoryData = {
 export function SellHistory() {
   const { nickname } = useAuthStore();
   const [isSold, setIsSold] = useState<boolean>();
-  const { data: historyData } = useQuery<HistoryData, Error>(
-    ['history', isSold],
-    () => getSellHistory({ nickname, isSold })
+  const {
+    data: historyData,
+    isLoading,
+    isError,
+  } = useQuery<HistoryData, Error>(['history', isSold], () =>
+    getSellHistory({ nickname, isSold })
   );
 
   // 무한 스크롤 구현
@@ -49,15 +54,19 @@ export function SellHistory() {
       </TopBar>
 
       <Body>
-        {historyData ? (
+        {isLoading ? (
+          <Loader />
+        ) : (
           <>
-            {historyData.items.map((item: ItemBaseType) => {
+            {historyData?.items.map((item: ItemBaseType) => {
               return <ProductItem key={item.id} {...item} isSeller={true} />;
             })}
           </>
-        ) : (
-          <div></div>
         )}
+        {historyData?.items.length === 0 && (
+          <Error message="판매 내역이 없습니다." />
+        )}
+        {isError && <Error message="판매 내역을 불러오지 못했습니다." />}
       </Body>
     </Div>
   );

--- a/src/page/home/Home.tsx
+++ b/src/page/home/Home.tsx
@@ -60,7 +60,7 @@ export function Home() {
     setCategoryId(id);
   };
 
-  const extractKeyName = (locationName: string) => {
+  const extractKeyName = (locationName: string | undefined) => {
     if (!locationName) return;
     const keyName = locationName.split(' ').at(-1);
     return keyName;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type ItemData = {
   nextCursor: number | null;
 };
 
-export type ItemProps = {
+export type ItemBaseType = {
   id: number;
   title: string;
   locationName: string;
@@ -17,6 +17,9 @@ export type ItemProps = {
     favorite: number;
   };
   thumbnailUrl: string;
+};
+
+export type ItemProps = ItemBaseType & {
   isSeller: boolean;
 };
 


### PR DESCRIPTION
## Description
- 판매 내역 페이지 구현
- 판매 내역과 관련되어 몇몇 리팩토링

## Key changes
![1](https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/6c5aeaec-c9bb-48c6-91dc-730c2087123d)
- Tabs는 Header와 똑같이 absolute로 구현해 상단에 고정되게 했습니다.
- 판매 내역 관련 msw 구현했습니다.
  - mainHandlers.ts -> itemsHandlers.ts로 변경
  - 이유는 main에서만 쓰는 곳이 였지만 item관련 handler가 모여 있다 생각해서 변경 했습니다.
  - 카테고리도 하나의 아이템이라 생각했습니다.
- BASE_URL 수정
  - new URL을 사용하기 위해서는 `http://` 까지 붙은 url 형식이여야 해서 BASE_URL을 변경했습니다.
- Badge 컴포넌트에 onClick props 추가 했습니다.
- `extractKeyName` 함수에 파라미터에 string으로만 되어 있어 undefined가 될 수 있다는 에러가 뜨고 있어 수정했습니다.
- `mainfetcher.ts`에서 url 만드는 부분 `searchParams`을 이용해서 만들도록 수정 했습니다.
## To reviewers
- 무한 스크롤은 따로 적용하지 않고 우선 컴포넌트 내에서 useQuery를 사용해서 api 호출하고 있습니다.
- 무한 스크롤은 홈, 판매 내역, 관심 내역에서 모두 똑같이 적용될 것이라 생각 했으며 기존에 있는 `useGetItemData`를 리팩토링 진행해서 3곳 모두 사용하게 만들 수 있을 것 같았습니다.
- 또 주석을 보니 지금 홈에 무한 스크롤에도 문제가 있다고 적혀 있고, 저보다 `useInfiniteQuery`를 많이 사용하신 퓨즈와 의논하면서 같이 리팩토링하면서 구현해도 좋을 것 같아서 냅두고 구현했습니다.

## Issue
- #74 
