### PR TITLE
관심 내역 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { Layout } from './components/Layout';
+import { FavoritesHistory } from './page/FavoritesHistory';
 import { SellHistory } from './page/SellHistory';
 import { Test } from './page/Test';
 import { MyAccount } from './page/auth/MyAccount';
@@ -29,6 +30,7 @@ export function App() {
           <Route path="/test" element={<Test />} />
           <Route path="/myAccount" element={<MyAccount />} />
           <Route path="/sellHistory" element={<SellHistory />} />
+          <Route path="/favoritesHistory" element={<FavoritesHistory />} />
           <Route
             path="/oauth2/authorization/github"
             element={<OAuthLoading />}

--- a/src/api/endPoint.ts
+++ b/src/api/endPoint.ts
@@ -8,4 +8,10 @@ export const API_ENDPOINT = {
   SELL_HISTORY: (nickname: string) => {
     return `/api/users/${nickname}/items`;
   },
+  FAVORITES_HISTORY: (categoryId?: number) => {
+    const param = categoryId ? `?categoryId=${categoryId}` : '';
+
+    return `/api/users/favorites${param}`;
+  },
+  FAVORITES_CATEGORY: '/api/users/favorites/categories',
 };

--- a/src/api/mainFetcher.ts
+++ b/src/api/mainFetcher.ts
@@ -38,3 +38,13 @@ export const getCategories = async () => {
   const res = await fetcher.get(API_ENDPOINT.CATEGORIES);
   return res.data;
 };
+
+export const getFavoritesCategories = async () => {
+  const res = await fetcher.get(API_ENDPOINT.FAVORITES_CATEGORY);
+  return res.data;
+};
+
+export const getFavoritesItemData = async (categoryId?: number) => {
+  const res = await fetcher.get(API_ENDPOINT.FAVORITES_HISTORY(categoryId));
+  return res.data;
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,7 +13,7 @@ export function Footer() {
         <Icon name="news" color="accentSecondary" />
         <Label>판매내역</Label>
       </Tab>
-      <Tab to="/">
+      <Tab to="/favoritesHistory">
         <Icon name="heart" color="systemWarning" />
         <Label>관심상품</Label>
       </Tab>

--- a/src/mocks/itemsHandlers.ts
+++ b/src/mocks/itemsHandlers.ts
@@ -32,6 +32,12 @@ export const itemsHandlers = [
       ctx.json({ ...sellHistoryData, items: newItems })
     );
   }),
+  rest.get(API_ENDPOINT.FAVORITES_CATEGORY, (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(categoryData));
+  }),
+  rest.get(API_ENDPOINT.FAVORITES_HISTORY(), (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(sellHistoryData));
+  }),
 ];
 
 const homeData: ItemData = {

--- a/src/page/FavoritesHistory.tsx
+++ b/src/page/FavoritesHistory.tsx
@@ -75,11 +75,9 @@ export function FavoritesHistory() {
         {isLoading ? (
           <Loader />
         ) : (
-          <>
-            {favoritesData?.items.map(item => {
-              return <ProductItem key={item.id} {...item} isSeller={true} />;
-            })}
-          </>
+          favoritesData?.items.map(item => {
+            return <ProductItem key={item.id} {...item} isSeller={true} />;
+          })
         )}
         {favoritesData?.items.length === 0 && (
           <Error message="판매 내역이 없습니다." />

--- a/src/page/FavoritesHistory.tsx
+++ b/src/page/FavoritesHistory.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useRef, useState } from 'react';
+import { styled } from 'styled-components';
+import { Badge, BadgeProps } from '../components/Badge';
+import { Error } from '../components/Error';
+import { Header } from '../components/Header';
+import { Loader } from '../components/Loader';
+import { ProductItem } from '../components/ProductItem';
+import {
+  useGetFavoritesCategoryData,
+  useGetFavoritesItemData,
+} from '../queries/useItemQuery';
+import { categoryTabsType } from '../types';
+
+export function FavoritesHistory() {
+  const [categoryTabs, setCategoryTabs] = useState<categoryTabsType[]>([
+    { name: '전체' },
+  ]);
+  const [selectedCategory, setSelectedCategory] = useState<number>();
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  const { data: categoryData } = useGetFavoritesCategoryData();
+  const {
+    data: favoritesData,
+    isError,
+    isLoading,
+  } = useGetFavoritesItemData(selectedCategory);
+
+  useEffect(() => {
+    categoryData &&
+      setCategoryTabs([{ name: '전체' }, ...categoryData.categories]);
+  }, [categoryData]);
+
+  useEffect(() => {
+    const element = tabsRef.current;
+    const scrollHandler = (event: WheelEvent) => {
+      event.preventDefault();
+
+      if (element) {
+        element.scrollLeft += event.deltaY;
+      }
+    };
+    element?.addEventListener('wheel', scrollHandler);
+
+    return () => {
+      element?.removeEventListener('wheel', scrollHandler);
+    };
+  }, []);
+
+  const setBadgeOption = (categoryTab: categoryTabsType) => {
+    const isSelected = categoryTab.id === selectedCategory;
+
+    const options: BadgeProps = {
+      text: categoryTab.name,
+      badgeColor: isSelected ? 'accentPrimary' : 'neutralBorder',
+      fontColor: isSelected ? 'accentText' : 'accentTextWeak',
+      size: 'M',
+      type: isSelected ? 'container' : 'outline',
+      onClick: () => setSelectedCategory(categoryTab.id),
+    };
+
+    return options;
+  };
+
+  return (
+    <Div>
+      <TopBar>
+        <Header title="판매 내역" />
+        <Tabs ref={tabsRef}>
+          {categoryTabs.map((categoryTab: categoryTabsType, index) => {
+            return <Badge key={index} {...setBadgeOption(categoryTab)} />;
+          })}
+        </Tabs>
+      </TopBar>
+      <Body>
+        {isLoading ? (
+          <Loader />
+        ) : (
+          <>
+            {favoritesData?.items.map(item => {
+              return <ProductItem key={item.id} {...item} isSeller={true} />;
+            })}
+          </>
+        )}
+        {favoritesData?.items.length === 0 && (
+          <Error message="판매 내역이 없습니다." />
+        )}
+        {isError && <Error message="판매 내역을 불러오지 못했습니다." />}
+      </Body>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
+const TopBar = styled.div`
+  width: 100%;
+  position: absolute;
+  z-index: 1;
+`;
+
+const Body = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 0 16px;
+  margin-top: 95px;
+`;
+
+const Tabs = styled.div`
+  width: 100%;
+  height: 48px;
+  display: flex;
+  position: relative;
+  gap: 4px;
+  padding: 8px 16px;
+  margin-top: 56px;
+  border-bottom: ${({ theme }) => `0.8px solid ${theme.color.neutralBorder}`};
+  background-color: ${({ theme }) => theme.color.accentText};
+  backdrop-filter: ${({ theme }) => theme.backdropFilter.blur};
+  overflow-y: hidden;
+  overflow-x: scroll;
+  white-space: nowrap;
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => theme.color.neutralBorderStrong};
+    border-radius: 10px;
+  }
+`;

--- a/src/queries/useItemQuery.ts
+++ b/src/queries/useItemQuery.ts
@@ -1,6 +1,10 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { getItems } from '../api/mainFetcher';
-import { ItemData } from '../types';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  getFavoritesCategories,
+  getFavoritesItemData,
+  getItems,
+} from '../api/mainFetcher';
+import { ItemData, categoryDataType } from '../types';
 
 const ITEMS_QUERY_KEY = '/items';
 
@@ -11,6 +15,19 @@ export const useGetItemData = (categoryId: number | null) => {
     {
       getNextPageParam: lastPage => lastPage.nextCursor ?? undefined,
     }
+  );
+};
+
+export const useGetFavoritesCategoryData = () => {
+  return useQuery<categoryDataType, Error>(
+    ['favoritesCategory'],
+    getFavoritesCategories
+  );
+};
+
+export const useGetFavoritesItemData = (categoryId?: number) => {
+  return useQuery<ItemData, Error>(['favoritesItems', categoryId], () =>
+    getFavoritesItemData(categoryId)
   );
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,12 @@ export type LocationResultData = {
   }[];
   nextPage: number | null;
 };
+
+export type categoryTabsType = {
+  id?: number;
+  name: string;
+};
+
+export type categoryDataType = {
+  categories: categoryTabsType[];
+};


### PR DESCRIPTION
## Description
관심 내역 페이지 구현 했습니다.

## Key changes
![1](https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/cc46dca4-c771-4e6c-9b12-9ef90240a06c)
- 판매 내역과 크게 다르지 않아서 쉽게 구현 했습니다.
  - 홈, 판매 내역, 관심 내역 모두 `Body`는 비슷하거나 동일한 구조를 가지고 있어 잘 하면 분리도 가능할 것 같습니다.
- 판매 내역에서 tabs는 최대 Badge가 3개 까지 나오고 있지만 관심 내역에서는 카테고리의 최대 개수 만큼 나올 수 있습니다.
  - 그래서 화면이 넘칠 수 있어 스크롤을 추가 했습니다.
  - tabs element 위에서 마우스 휠을 사용하여 스크롤 가능 하게 구현 했습니다.

## To reviewers
- 판매 내역과 마찬가지로 무한 스크롤은 따로 구현하지 않았습니다.

## Issue
- #76
