### PR TITLE
기타 리팩토링

### DIFF
--- a/src/api/queries/useItemQuery.ts
+++ b/src/api/queries/useItemQuery.ts
@@ -5,7 +5,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { SalesListData } from '../../page/SalesList';
-import { CategoryData, ItemData, categoryDataType } from '../../types';
+import { CategoryData, FavoritesCategoryDataType, ItemData } from '../../types';
 import {
   deleteItem,
   getFavorites,
@@ -68,7 +68,7 @@ export const useGetFavorites = (categoryId?: number) => {
 };
 
 export const useGetFavoritesCategoryData = () => {
-  return useQuery<categoryDataType>(
+  return useQuery<FavoritesCategoryDataType>(
     [FAVORITES_CATEGORY],
     getFavoritesCategories
   );

--- a/src/page/Favorites.tsx
+++ b/src/page/Favorites.tsx
@@ -10,12 +10,12 @@ import { Error } from '../components/Error';
 import { Header } from '../components/Header';
 import { Loader } from '../components/Loader';
 import { ProductItem } from '../components/ProductItem';
-import { categoryTabsType } from '../types';
+import { FavoritesCategoryTabsType } from '../types';
 
 export function Favorites() {
-  const [categoryTabs, setCategoryTabs] = useState<categoryTabsType[]>([
-    { name: '전체' },
-  ]);
+  const [categoryTabs, setCategoryTabs] = useState<FavoritesCategoryTabsType[]>(
+    [{ name: '전체' }]
+  );
   const [selectedCategory, setSelectedCategory] = useState<number>();
   const tabsRef = useRef<HTMLDivElement>(null);
   const { ref: observingTargetRef, inView } = useInView();
@@ -56,7 +56,7 @@ export function Favorites() {
     };
   }, []);
 
-  const setBadgeOption = (categoryTab: categoryTabsType) => {
+  const setBadgeOption = (categoryTab: FavoritesCategoryTabsType) => {
     const isSelected = categoryTab.id === selectedCategory;
 
     const options: BadgeProps = {
@@ -76,7 +76,7 @@ export function Favorites() {
       <TopBar>
         <Header title="관심 목록" />
         <Tabs ref={tabsRef}>
-          {categoryTabs.map((categoryTab: categoryTabsType, index) => {
+          {categoryTabs.map((categoryTab: FavoritesCategoryTabsType, index) => {
             return <Badge key={index} {...setBadgeOption(categoryTab)} />;
           })}
         </Tabs>

--- a/src/page/auth/ProfileButton.tsx
+++ b/src/page/auth/ProfileButton.tsx
@@ -35,11 +35,13 @@ export function ProfileButton({
         onClick={() => inputRef.current?.click()}
         $backgroundImage={backgroundImage}
       >
-        <Icon name="camera" color="accentText" />
+        <IconWrapper $backgroundImage={backgroundImage}>
+          <Icon name="camera" color="accentText" />
+        </IconWrapper>
         {(file || backgroundImage) && (
-          <Test onClick={onOpenAlert}>
+          <RemoveButton onClick={onOpenAlert}>
             <Icon name="x" color="accentText" />
-          </Test>
+          </RemoveButton>
         )}
       </ImageButton>
       <input
@@ -85,7 +87,15 @@ const ImageButton = styled.button<{ $backgroundImage: string | undefined }>`
   cursor: pointer;
 `;
 
-const Test = styled.div`
+const IconWrapper = styled.div<{ $backgroundImage: string | undefined }>`
+  display: ${({ $backgroundImage }) => ($backgroundImage ? 'none' : 'block')};
+
+  ${ImageButton}:hover & {
+    display: block;
+  }
+`;
+
+const RemoveButton = styled.div`
   width: 28px;
   height: 28px;
   position: absolute;

--- a/src/page/productEditor/CategoryContainer.tsx
+++ b/src/page/productEditor/CategoryContainer.tsx
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 import { Badge, BadgeProps } from '../../components/Badge';
 import { Button } from '../../components/button/Button';
 import { Icon } from '../../components/icon/Icon';
-import { categoryTabsType } from '../../types';
+import { FavoritesCategoryTabsType } from '../../types';
 import { CategoryData } from './ProductEditorPanel';
 
 type CategoryContainerProps = {
@@ -18,7 +18,7 @@ export function CategoryContainer({
   openModal,
   setCategoryId,
 }: CategoryContainerProps) {
-  const setBadgeOption = (category: categoryTabsType) => {
+  const setBadgeOption = (category: FavoritesCategoryTabsType) => {
     const isSelected = category.id === selectedCategoryId;
     const options: BadgeProps = {
       size: 'M',

--- a/src/page/productEditor/PictureContainer.tsx
+++ b/src/page/productEditor/PictureContainer.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef } from 'react';
+import { ChangeEvent, useMemo, useRef } from 'react';
 import { styled } from 'styled-components';
 import { Button } from '../../components/button/Button';
 import { Icon } from '../../components/icon/Icon';
@@ -18,6 +18,9 @@ export function PictureContainer({
   deletePicture,
 }: PictureContainerProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const memoizedUrls = useMemo(() => {
+    return uploadPictureList.map(picture => URL.createObjectURL(picture));
+  }, [uploadPictureList]);
 
   return (
     <>
@@ -50,13 +53,12 @@ export function PictureContainer({
             </Picture>
           );
         })}
-        {uploadPictureList.map((picture, index) => {
+        {memoizedUrls.map((url, index) => {
           return (
-            <Picture
-              key={index}
-              $backgroundImage={URL.createObjectURL(picture)}
-            >
-              <PictureDeleteButton onClick={() => deletePicture(picture)}>
+            <Picture key={index} $backgroundImage={url}>
+              <PictureDeleteButton
+                onClick={() => deletePicture(uploadPictureList[index])}
+              >
                 <Icon name="x" color="accentText" />
               </PictureDeleteButton>
               {pictureList.length === 0 && index === 0 && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,13 +44,13 @@ export type LocationResultData = {
   nextPage: number | null;
 };
 
-export type categoryTabsType = {
+export type FavoritesCategoryTabsType = {
   id?: number;
   name: string;
 };
 
-export type categoryDataType = {
-  categories: categoryTabsType[];
+export type FavoritesCategoryDataType = {
+  categories: FavoritesCategoryTabsType[];
 };
 
 export type CategoryData = {


### PR DESCRIPTION
## Description
- 4주차 pr 작성 전 현재로 바로 리팩토링 가능한 부분만 진행 했습니다.
## Key changes
- 비슷한 이름의 type명 수정 했습니다.
- 닉네임 input 위치는 그대로 가기로 합의 했습니다.
- profileButton에 카메라 아이콘은 배경이 있는 경우 hover 할 경우에만 보이게 변경 했습니다.
- 이미지를 업로드 한 후 해당 페이지가 재 랜더링 될 때 마다 이미지가 깜빡이는 현상 수정 했습니다.
  - 이 현상이 생기는 이유는 업로드한 파일을 `URL.createObjectURL()`을 통해서 url로 만드는 과정이 있습니다.
  - 이 과정은 브라우저의 메모리에 올라간 이미지, 파일 등을 url로 만들고 이 url을 css에서 background로 사용하고 있기 때문에 네트워크 텝에서 get요청도 볼 수 있습니다.
  - 그렇기 때문에 input이나 textarea에서 입력을 진행하면 해당 페이지가 재 랜더링이 발생하고 그럼 해당 페이지의 업로드해 놓은 이미지 개수 만큼 `URL.createObjectURL()` 메서드가 돌면서 url을 만들고 그 개수 만큼 get요청으로 background가 적용되기 때문에 이미지가 깜빡입니다.
  - 지금은 이미지가 2개 지만 만약 저희 프로젝트에서 최대 개수인 10개를 넣거나 아니면 더 큰 프로젝트에서 그 이상 몇백 몇천개를 넣고 타이핑을 정말 빠르게 했다면 문제가 더 클 것 같네요.
    - 10개를 넣고 약 5초 간 키를 꾹 눌렀는데 브라우저가 멈췄습니다.
  - 결론은 useMemo를 사용해 `uploadPictureList`의 파일이 바뀌지 않는 다면 `URL.createObjectURL()` 메서드가 더 이상 돌지 않게 했습니다.

## 개선 전
https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/14e2b5ed-4220-4427-a54d-5009cd42feef

## 개선 후
https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/41321198/0e374cb4-49a4-4968-b7ea-4c55526da637

## Issue
- #85
