### PR TITLE
4주차 PR전 피드백 반영 및 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SalesList } from './page/SalesList';
 import { MyAccount } from './page/auth/MyAccount';
 import { OAuthLoading } from './page/auth/OAuthLoading';
 import { Home } from './page/home/Home';
+import { ProtectedRoute } from './router/ProtectedRoute';
 import { useScreenConfigStore } from './stores/useScreenConfigStore';
 import elephantImg from '/elephant-bg.png';
 
@@ -29,15 +30,18 @@ export function App() {
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/items/:itemId" element={<ItemDetails />} />
-          <Route path="/sellHistory" element={<SalesList />} />
-          <Route path="/favoritesHistory" element={<Favorites />} />
-          <Route path="/chat" element={<Chatting />} />
           <Route path="/myAccount" element={<MyAccount />} />
           <Route
             path="/oauth2/authorization/github"
             element={<OAuthLoading />}
           />
           <Route path="/login/oauth2/code/github" element={<OAuthLoading />} />
+
+          <Route element={<ProtectedRoute />}>
+            <Route path="/sellHistory" element={<SalesList />} />
+            <Route path="/favoritesHistory" element={<Favorites />} />
+            <Route path="/chat" element={<Chatting />} />
+          </Route>
         </Route>
       </Routes>
     </AppContainer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { Layout } from './components/Layout';
+import { Chatting } from './page/Chatting';
 import { Favorites } from './page/Favorites';
 import { ItemDetails } from './page/ItemDetails';
 import { SalesList } from './page/SalesList';
@@ -28,9 +29,10 @@ export function App() {
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/items/:itemId" element={<ItemDetails />} />
-          <Route path="/myAccount" element={<MyAccount />} />
           <Route path="/sellHistory" element={<SalesList />} />
           <Route path="/favoritesHistory" element={<Favorites />} />
+          <Route path="/chat" element={<Chatting />} />
+          <Route path="/myAccount" element={<MyAccount />} />
           <Route
             path="/oauth2/authorization/github"
             element={<OAuthLoading />}

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -10,7 +10,6 @@ export const fetcher = axios.create({
   baseURL: BASE_URL,
   headers: {
     'Content-Type': 'application/json',
-    'Refresh-Token': 'your-refresh-token-value',
   },
 });
 

--- a/src/api/queries/useItemQuery.ts
+++ b/src/api/queries/useItemQuery.ts
@@ -8,6 +8,7 @@ import { SalesListData } from '../../page/SalesList';
 import { CategoryData, ItemData, categoryDataType } from '../../types';
 import {
   deleteItem,
+  getCategories,
   getFavorites,
   getFavoritesCategories,
   getItems,
@@ -16,6 +17,7 @@ import {
 } from '../fetchers/itemFetcher';
 
 const ITEMS_QUERY_KEY = 'items';
+const CATEGORY_QUERY_KEY = 'category';
 const SALES_LIST_QUERY_KEY = 'salesList';
 const FAVORITES_QUERY_KEY = 'favorites';
 const RECOMMEND_CATEGORY = 'recommendCategory';
@@ -38,6 +40,12 @@ export const useDeleteItem = () => {
     onSuccess: () => {
       queryClient.invalidateQueries([ITEMS_QUERY_KEY]);
     },
+  });
+};
+
+export const useGetCategoryData = () => {
+  return useQuery<CategoryData>([CATEGORY_QUERY_KEY], getCategories, {
+    staleTime: Infinity,
   });
 };
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,9 +17,9 @@ export function Footer() {
         <Icon name="heart" color="systemWarning" />
         <Label>관심상품</Label>
       </Tab>
-      <Tab to="/test">
-        <Icon name="check" color="accentTextWeak" />
-        <Label>test</Label>
+      <Tab to="/chat">
+        <Icon name="message" color="neutralTextWeak" />
+        <Label>채팅</Label>
       </Tab>
       <Tab to="/myAccount">
         <Icon name="userCircle" color="neutralTextWeak" />

--- a/src/components/ProductItem.tsx
+++ b/src/components/ProductItem.tsx
@@ -138,7 +138,7 @@ export function ProductItem({
           {favorite > 0 && (
             <CountWrapper>
               <Icon name="heart" color="neutralTextWeak" />
-              {chat}
+              {favorite}
             </CountWrapper>
           )}
         </History>

--- a/src/components/itemDetails/ImageSlider.tsx
+++ b/src/components/itemDetails/ImageSlider.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { styled } from 'styled-components';
 import { Badge } from '../Badge';
+import { Error } from '../Error';
 
 type ImageSliderProps = {
   imageList: { id: number; url: string }[];
@@ -88,13 +89,17 @@ export function ImageSlider({ imageList }: ImageSliderProps) {
           />
         ))}
       </Slider>
-      <PageNav
-        fontColor="neutralTextWeak"
-        badgeColor="neutralBackgroundBlur"
-        text={`${currentImageIndex} / ${imageList.length}`}
-        size="M"
-        type="container"
-      />
+      {imageList.length === 0 ? (
+        <Error message="등록된 이미지가 없습니다." />
+      ) : (
+        <PageNav
+          fontColor="neutralTextWeak"
+          badgeColor="neutralBackgroundBlur"
+          text={`${currentImageIndex} / ${imageList.length}`}
+          size="M"
+          type="container"
+        />
+      )}
     </Container>
   );
 }

--- a/src/components/itemDetails/ItemDetailsSkeleton.tsx
+++ b/src/components/itemDetails/ItemDetailsSkeleton.tsx
@@ -1,0 +1,153 @@
+import { keyframes, styled } from 'styled-components';
+import { Button } from '../button/Button';
+
+export function ItemDetailsSkeleton() {
+  return (
+    <Container>
+      <Main>
+        <SkeletonImageSlider />
+        <Body>
+          <SkeletonWrapper>
+            <SellerInfo>
+              <SkeletonButton
+                color="neutralBackgroundWeak"
+                align="space-between"
+              >
+                {' '}
+              </SkeletonButton>
+            </SellerInfo>
+            <SkeletonHeader />
+            <SkeletonBody />
+            <SkeletonCountData />
+            <ShimmerWrapper>
+              <Shimmer />
+            </ShimmerWrapper>
+          </SkeletonWrapper>
+        </Body>
+      </Main>
+      <Footer></Footer>
+    </Container>
+  );
+}
+
+const loading = keyframes`
+  0% {
+   transform: translateX(-150%);
+  }
+  50% {
+   transform: translateX(-60%);
+  }
+  100% {
+   transform: translateX(150%);
+  }
+`;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  z-index: 1;
+  background-color: ${({ theme }) => theme.color.neutralBackground};
+`;
+
+const SkeletonImageSlider = styled.div`
+  width: 100%;
+  height: 491px;
+  position: relative;
+  background-color: ${({ theme }) => theme.color.neutralBorder};
+`;
+
+const Main = styled.div`
+  height: 786px;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
+const Body = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  position: relative;
+`;
+
+const SellerInfo = styled.div`
+  width: 361px;
+`;
+
+const SkeletonButton = styled(Button)`
+  background-color: ${({ theme }) => theme.color.neutralBorder};
+`;
+
+const SkeletonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+`;
+
+const SkeletonHeader = styled.div`
+  width: 200px;
+  height: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  align-self: stretch;
+  background-color: ${({ theme }) => theme.color.neutralBorder};
+`;
+
+const SkeletonBody = styled.div`
+  width: 100%;
+  height: 60px;
+  font: ${({ theme }) => theme.font.displayDefault16};
+  color: ${({ theme }) => theme.color.neutralText};
+  background-color: ${({ theme }) => theme.color.neutralBorder};
+`;
+
+const SkeletonCountData = styled.div`
+  height: 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  align-self: stretch;
+  font: ${({ theme }) => theme.font.displayDefault12};
+  color: ${({ theme }) => theme.color.neutralTextWeak};
+  background-color: ${({ theme }) => theme.color.neutralBorder};
+`;
+
+const ShimmerWrapper = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const Shimmer = styled.div`
+  width: 50%;
+  height: 100%;
+  opacity: 0.2;
+  background: ${({ theme }) => theme.color.neutralBackgroundBlur};
+  transform: skewX(-20deg);
+  animation: ${loading} 1s linear infinite;
+`;
+
+const Footer = styled.div`
+  width: 100%;
+  height: 64px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px;
+  border-top: ${({ theme }) => `0.8px solid ${theme.color.neutralBorder}`};
+  position: absolute;
+  bottom: 0;
+  background-color: ${({ theme }) => theme.color.neutralBackgroundWeak};
+`;

--- a/src/components/locations/AddLocation.tsx
+++ b/src/components/locations/AddLocation.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { styled } from 'styled-components';
-import {
-  useAddUserLocation,
-  useGetLocationResult,
-} from '../../api/queries/useLocationQuery';
+import { useGetLocationResult } from '../../api/queries/useLocationQuery';
 import { useDebounceValue } from '../../hooks/useDebounceValue';
 import { Error } from '../Error';
 import { Loader } from '../Loader';
@@ -12,17 +9,15 @@ import { Loader } from '../Loader';
 type AddLocationProps = {
   rightPosition?: number;
   showSearchPanel?: () => void;
-  closeSearchPanel?: () => void;
-  hideSearchPanel?: () => void;
-  addLocation?: (locationId: number, locationName: string) => void;
+  onTransitionEndHandler?: () => void;
+  clickLocationItem: (locationId: number, locationName: string) => void;
 };
 
 export function AddLocation({
   rightPosition,
   showSearchPanel,
-  closeSearchPanel,
-  hideSearchPanel,
-  addLocation,
+  onTransitionEndHandler,
+  clickLocationItem,
 }: AddLocationProps) {
   const [inputValue, setInputValue] = useState('');
   const query = useDebounceValue(inputValue, 500);
@@ -36,7 +31,6 @@ export function AddLocation({
     fetchNextPage,
   } = useGetLocationResult(query);
 
-  const addMutation = useAddUserLocation();
   const { ref: observingTargetRef, inView } = useInView();
 
   useEffect(() => {
@@ -48,21 +42,6 @@ export function AddLocation({
   useEffect(() => {
     showSearchPanel && showSearchPanel();
   }, [showSearchPanel]);
-
-  const onClickLocationItem = (locationId: number, locationName: string) => {
-    // SignUpPanel에서 사용하는 경우
-    if (addLocation) {
-      addLocation(locationId, locationName);
-      return;
-    }
-    // Home에서 사용하는 경우
-    addMutation.mutate({ locationId, locationName });
-    hideSearchPanel && hideSearchPanel();
-  };
-
-  const onTransitionEndHandler = () => {
-    rightPosition !== 0 && closeSearchPanel && closeSearchPanel();
-  };
 
   const onChangeInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
@@ -90,7 +69,7 @@ export function AddLocation({
                   <LocationItem
                     key={location.id}
                     onClick={() =>
-                      onClickLocationItem(location.id, location.name)
+                      clickLocationItem(location.id, location.name)
                     }
                   >
                     {location.name}

--- a/src/components/locations/HomeLocationModal.tsx
+++ b/src/components/locations/HomeLocationModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { styled } from 'styled-components';
+import { useAddUserLocation } from '../../api/queries/useLocationQuery';
 import { Modal } from '../Modal';
 import { Button } from '../button/Button';
 import { Icon } from '../icon/Icon';
@@ -15,6 +16,8 @@ export function HomeLocationModal({ isOpen, onClose }: LocationModalProps) {
   const [isAddLocation, setIsAddLocation] = useState(false);
   const [rightPosition, setRightPosition] = useState(-320);
 
+  const addUserLocation = useAddUserLocation();
+
   const openSearchPanel = () => {
     setIsAddLocation(true);
   };
@@ -29,6 +32,15 @@ export function HomeLocationModal({ isOpen, onClose }: LocationModalProps) {
 
   const hideSearchPanel = () => {
     setRightPosition(-320);
+  };
+
+  const onTransitionEndHandler = () => {
+    rightPosition !== 0 && closeSearchPanel();
+  };
+
+  const clickLocationItem = (locationId: number, locationName: string) => {
+    addUserLocation.mutate({ locationId, locationName });
+    hideSearchPanel();
   };
 
   return (
@@ -51,8 +63,8 @@ export function HomeLocationModal({ isOpen, onClose }: LocationModalProps) {
           <AddLocation
             rightPosition={rightPosition}
             showSearchPanel={showSearchPanel}
-            closeSearchPanel={closeSearchPanel}
-            hideSearchPanel={hideSearchPanel}
+            onTransitionEndHandler={onTransitionEndHandler}
+            clickLocationItem={clickLocationItem}
           />
         )}
       </Body>

--- a/src/components/locations/SignUpLocationModal.tsx
+++ b/src/components/locations/SignUpLocationModal.tsx
@@ -7,13 +7,13 @@ import { AddLocation } from './AddLocation';
 type LocationModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  addLocation: (locationId: number, locationName: string) => void;
+  setSignUpLocation: (locationId: number, locationName: string) => void;
 };
 
 export function SignUpLocationModal({
   isOpen,
   onClose,
-  addLocation,
+  setSignUpLocation,
 }: LocationModalProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -24,7 +24,7 @@ export function SignUpLocationModal({
         </Button>
       </Header>
       <Body>
-        <AddLocation addLocation={addLocation} />
+        <AddLocation clickLocationItem={setSignUpLocation} />
       </Body>
     </Modal>
   );

--- a/src/page/Chatting.tsx
+++ b/src/page/Chatting.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { Header } from '../components/Header';
+
+export function Chatting() {
+  return (
+    <Container>
+      <Header title="채팅" />
+      <Body>
+        <div>채팅 페이지 구현 예정</div>
+      </Body>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+`;
+
+const Body = styled.div`
+  flex: 1;
+  margin-top: 56px;
+`;

--- a/src/page/ItemDetails.tsx
+++ b/src/page/ItemDetails.tsx
@@ -11,6 +11,7 @@ import { useDeleteItem } from '../api/queries/useItemQuery';
 import { Alert } from '../components/Alert';
 import { Error } from '../components/Error';
 import { Header } from '../components/Header';
+import { Loader } from '../components/Loader';
 import { Button } from '../components/button/Button';
 import { Dropdown } from '../components/dropdown/Dropdown';
 import { MenuItem } from '../components/dropdown/MenuItem';
@@ -95,11 +96,19 @@ export function ItemDetails() {
 
   // TODO: 페이지 로딩 시 스켈레톤 UI 추가 예정
   if (isLoading) {
-    return <div>loading...</div>;
+    return (
+      <Wrapper>
+        <Loader />
+      </Wrapper>
+    );
   }
 
   if (isError) {
-    return <Error />;
+    return (
+      <Wrapper>
+        <Error />
+      </Wrapper>
+    );
   }
 
   const toggleFavorites = () => {
@@ -235,6 +244,10 @@ export function ItemDetails() {
     </Container>
   );
 }
+
+const Wrapper = styled.div`
+  flex: 1;
+`;
 
 const Container = styled.div`
   width: 100%;

--- a/src/page/ItemDetails.tsx
+++ b/src/page/ItemDetails.tsx
@@ -61,7 +61,7 @@ export function ItemDetails() {
   const deleteMutation = useDeleteItem();
   const navigate = useNavigate();
 
-  const fakeAction = () => {
+  const openEditPanel = () => {
     if (!itemDetailsEditData || isLoadingEdit) {
       // '문제가 생겼습니다 다시 시도해 주세요' 같은 toast
       // 또는 잠깐 로딩 보여주고 data, isLoading을 useEffect로 체크 후 panel 열어 주기
@@ -151,7 +151,7 @@ export function ItemDetails() {
           itemDetailsData.isSeller ? (
             <div onMouseOver={hoverToFetch}>
               <Dropdown iconName="dots" align="right">
-                <MenuItem onAction={fakeAction}>게시글 수정</MenuItem>
+                <MenuItem onAction={openEditPanel}>게시글 수정</MenuItem>
                 <MenuItem color="systemWarning" onAction={onClickDelete}>
                   삭제
                 </MenuItem>

--- a/src/page/auth/LoginPage.tsx
+++ b/src/page/auth/LoginPage.tsx
@@ -1,16 +1,18 @@
 import { ChangeEvent, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
-import { useLogin } from '../../api/fetchers/authFetcher';
 import { BASE_URL } from '../../api/axios';
+import { useLogin } from '../../api/fetchers/authFetcher';
 import { Button } from '../../components/button/Button';
 import { Icon } from '../../components/icon/Icon';
 import { AuthInput } from './AuthInput';
 import { SignUpPanel } from './SignUpPanel';
 
 export function LoginPage() {
-  const navigate = useNavigate();
   const { login } = useLogin();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = location?.state?.redirectedFrom.pathname || '/';
 
   const [isOpenPanel, setIsOpenPanel] = useState(false);
   const [id, setId] = useState('');
@@ -44,7 +46,7 @@ export function LoginPage() {
     });
 
     if (res.status === 200) {
-      navigate('/');
+      navigate(from);
     }
   };
 

--- a/src/page/auth/MyAccount.tsx
+++ b/src/page/auth/MyAccount.tsx
@@ -1,4 +1,3 @@
-import { Header } from '../../components/Header';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { LoginPage } from './LoginPage';
 import { MyProfilePage } from './MyProfilePage';
@@ -12,10 +11,5 @@ export function MyAccount() {
     nickname !== '' &&
     profileImageUrl !== '';
 
-  return (
-    <>
-      <Header title="내 계정" />
-      {isLogin ? <MyProfilePage /> : <LoginPage />}
-    </>
-  );
+  return <>{isLogin ? <MyProfilePage /> : <LoginPage />}</>;
 }

--- a/src/page/auth/SignUpPanel.tsx
+++ b/src/page/auth/SignUpPanel.tsx
@@ -49,11 +49,6 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
     !isNullLocation
   );
 
-  const addSignUpLocation = (locationId: number, locationName: string) => {
-    setLocation({ id: locationId, name: locationName });
-    setIsModalOpen(false);
-  };
-
   useEffect(() => {
     setRightPosition(0);
   }, []);
@@ -143,6 +138,11 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
     }
   };
 
+  const setSignUpLocation = (locationId: number, locationName: string) => {
+    setLocation({ id: locationId, name: locationName });
+    setIsModalOpen(false);
+  };
+
   return (
     <Div $right={rightPosition} onTransitionEnd={onTransitionEndHandler}>
       <Header
@@ -217,7 +217,7 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
         <SignUpLocationModal
           isOpen={isModalOpen}
           onClose={closeModal}
-          addLocation={addSignUpLocation}
+          setSignUpLocation={setSignUpLocation}
         />
       )}
     </Div>

--- a/src/page/home/CategoryFilterPanel.tsx
+++ b/src/page/home/CategoryFilterPanel.tsx
@@ -1,7 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
 import { memo, useEffect, useState } from 'react';
 import { styled } from 'styled-components';
-import { getCategories } from '../../api/fetchers/itemFetcher';
+import { useGetCategoryData } from '../../api/queries/useItemQuery';
 import { categoryIconMap } from '../../assets/image';
 import { Error } from '../../components/Error';
 import { Header } from '../../components/Header';
@@ -9,16 +8,6 @@ import { Loader } from '../../components/Loader';
 import { Button } from '../../components/button/Button';
 import { Icon } from '../../components/icon/Icon';
 import { useScreenConfigStore } from '../../stores/useScreenConfigStore';
-
-type CategoryData = {
-  categories: CategoryItem[];
-};
-
-type CategoryItem = {
-  id: number;
-  name: string;
-  iconName: string;
-};
 
 type CategoryFilterPanelProps = {
   closePanel: () => void;
@@ -33,11 +22,7 @@ export const CategoryFilterPanel = memo(
       isOpenPanel ? 0 : -screenWidth
     );
 
-    const {
-      data: categoryData,
-      isLoading,
-      isError,
-    } = useQuery<CategoryData, Error>(['category'], getCategories);
+    const { data: categoryData, isLoading, isError } = useGetCategoryData();
 
     useEffect(() => {
       if (isOpenPanel) {

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuthStore } from '../stores/useAuthStore';
+
+export function ProtectedRoute() {
+  const currentLocation = useLocation();
+  const { accessToken, refreshToken, nickname, profileImageUrl } =
+    useAuthStore();
+
+  const isLogin =
+    accessToken !== '' &&
+    refreshToken !== '' &&
+    nickname !== '' &&
+    profileImageUrl !== '';
+
+  return isLogin ? (
+    <Outlet />
+  ) : (
+    <Navigate
+      to={'/myAccount'}
+      replace
+      state={{ redirectedFrom: currentLocation }}
+    />
+  );
+}


### PR DESCRIPTION
## Description
- 이번주 마일스톤 작업과 리뷰어 피드백 받은 부분 + 작업하면서 생긴 여러 수정사항들을 반영했습니다.

## Key changes
- 기존 Test 페이지 삭제하고 임시로 채팅 페이지를 만들어 두었습니다.
- 우선 판매내역, 관심목록, 채팅페이지에 ProtectedRoute 구현해서 적용했습니다.
- CategoryFilterPanel에 있던 useQuery 훅도 커스텀 훅으로 분리하고 staleTime: Infinity로 설정해서 최초 한번만 받아오도록 수정했습니다.
- 상세페이지에서 보여지는 Loader, Error 컴포넌트를 Wrapper로 감싸 Footer가 화면 중앙에 보이지 않도록 수정했습니다.
- 이제 서버에서 Refresh-Token이 잘 받아와져서 axios에 불필요한 옵션 삭제했습니다.
- 상세페이지에서 보여줄 Skeleton UI 구현하긴 했는데 실제로 테스트 해보니 로딩 시간이 너무 짧아서 화면이 깜빡이네요. 일단 <Loader/>를 렌더링하게 해 두었습니다.
- addLocation 관련 내부 로직 수정하였습니다. 이제 사용하는 곳에 맞는 clickLocationItem 동작을 props로 받아서 실행합니다.

## To reviewers

## Issue
- #86 