### PR TITLE
사소한 수정 및 리팩토링

### DIFF
--- a/src/api/fetchers/authFetcher.ts
+++ b/src/api/fetchers/authFetcher.ts
@@ -29,7 +29,7 @@ export const useLogin = () => {
       const accessToken = res.headers['authorization'];
       const refreshToken = res.headers['refresh-token'];
       const userInfo = res.data;
-      // headers의 refresh_token은 을 못 읽어오는 문제 해결 필요
+
       setStateAccessToken(accessToken);
       setStateRefreshToken(refreshToken);
       setStateUserInfo(userInfo);

--- a/src/api/fetchers/itemFetcher.ts
+++ b/src/api/fetchers/itemFetcher.ts
@@ -68,8 +68,10 @@ export const getFavoritesCategories = async () => {
   return res.data;
 };
 
-export const getRecommendCategories = async () => {
-  const res = await fetcher.get(API_ENDPOINT.RECOMMENDED_CATEGORIES);
+export const getRecommendCategories = async (title: string) => {
+  const res = await fetcher.get(
+    `${API_ENDPOINT.RECOMMENDED_CATEGORIES}?title=${title}`
+  );
 
   return res.data;
 };

--- a/src/api/queries/useItemQuery.ts
+++ b/src/api/queries/useItemQuery.ts
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-query';
 import { SalesListData } from '../../page/SalesList';
 import { CategoryData, FavoritesCategoryDataType, ItemData } from '../../types';
+import { patchStatus } from '../fetchers/itemDetailsFetcher';
 import {
   deleteItem,
   getCategories,
@@ -33,12 +34,19 @@ export const useGetItemData = (categoryId?: number) => {
   );
 };
 
-export const useDeleteItem = () => {
+export const useDeleteItem = (
+  refetchTarget: 'home' | 'favorites' | 'salesList'
+) => {
   const queryClient = useQueryClient();
+  const key = {
+    home: ITEMS_QUERY_KEY,
+    favorites: FAVORITES_QUERY_KEY,
+    salesList: SALES_LIST_QUERY_KEY,
+  };
 
   return useMutation(deleteItem, {
     onSuccess: () => {
-      queryClient.invalidateQueries([ITEMS_QUERY_KEY]);
+      queryClient.invalidateQueries([key[refetchTarget]]);
     },
   });
 };
@@ -98,4 +106,21 @@ export const useResetRecommendCategory = () => {
     queryClient.resetQueries({
       queryKey: [RECOMMEND_CATEGORY],
     });
+};
+
+export const usePatchItemStatus = (
+  refetchTarget: 'home' | 'favorites' | 'salesList'
+) => {
+  const queryClient = useQueryClient();
+  const key = {
+    home: ITEMS_QUERY_KEY,
+    favorites: FAVORITES_QUERY_KEY,
+    salesList: SALES_LIST_QUERY_KEY,
+  };
+
+  return useMutation(patchStatus, {
+    onSuccess: () => {
+      queryClient.invalidateQueries([key[refetchTarget]]);
+    },
+  });
 };

--- a/src/api/queries/useItemQuery.ts
+++ b/src/api/queries/useItemQuery.ts
@@ -82,10 +82,14 @@ export const useGetFavoritesCategoryData = () => {
   );
 };
 
-export const useGetRecommendCategoryData = () => {
-  return useQuery<CategoryData>([RECOMMEND_CATEGORY], getRecommendCategories, {
-    enabled: false,
-  });
+export const useGetRecommendCategoryData = (title: string) => {
+  return useQuery<CategoryData>(
+    [RECOMMEND_CATEGORY],
+    () => getRecommendCategories(title),
+    {
+      enabled: false,
+    }
+  );
 };
 
 export const useResetRecommendCategory = () => {

--- a/src/components/ProductItem.tsx
+++ b/src/components/ProductItem.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { useGetItemDetailsEdit } from '../api/queries/useItemDetailsQuery';
+import { useDeleteItem, usePatchItemStatus } from '../api/queries/useItemQuery';
 import { useProductEditorStore } from '../stores/useProductEditorStore';
 import { useToastStore } from '../stores/useToastStore';
 import { addCommasToNumber } from '../utils/addCommasToNumber';
@@ -35,10 +36,14 @@ export function ProductItem({
   countData,
   thumbnailUrl,
   isSeller,
-}: ItemProps) {
+  renderingPosition,
+}: ItemProps & { renderingPosition: 'home' | 'favorites' | 'salesList' }) {
   const navigate = useNavigate();
   const showToast = useToastStore(state => state.showToast);
   const openEditorPanel = useProductEditorStore(state => state.openPanel);
+  const statusMutation = usePatchItemStatus(renderingPosition);
+  const deleteMutation = useDeleteItem(renderingPosition);
+
   const { data, isError, isLoading, refetch } = useGetItemDetailsEdit(id);
   const { chat, favorite } = countData;
 
@@ -78,13 +83,19 @@ export function ProductItem({
       openEditorPanel({ mode: 'edit', data: data, id: id });
     },
     reserved: () => {
-      console.log('예약중');
+      statusMutation.mutate({
+        itemId: id,
+        statusName: '예약중',
+      });
     },
-    sold: () => {
-      console.log('판매완료');
+    sold: async () => {
+      statusMutation.mutate({
+        itemId: id,
+        statusName: '판매완료',
+      });
     },
     delete: () => {
-      console.log('삭제');
+      deleteMutation.mutate(id);
     },
   };
 

--- a/src/components/ProductItem.tsx
+++ b/src/components/ProductItem.tsx
@@ -64,7 +64,6 @@ export function ProductItem({
     }
   };
 
-  // TODO: 각 드롭다운 메뉴 아이템들에 맞는 액션 추가하기
   const dropdownActions = {
     edit: () => {
       if (!data || isLoading) {

--- a/src/mocks/faker.ts
+++ b/src/mocks/faker.ts
@@ -7,7 +7,6 @@ const thumbnailList = [
   'https://www.ikea.com/kr/ko/images/products/idanaes-high-cabinet-w-gls-drs-and-1-drawer-dark-brown-stained__1008948_pe827389_s5.jpg?f=xl',
 ];
 
-// 무한 스크롤 목 데이터 구현 필요
 export const fakeItems = () => {
   const items = [];
   for (let i = 2; i <= 20; i++) {

--- a/src/page/Favorites.tsx
+++ b/src/page/Favorites.tsx
@@ -44,7 +44,7 @@ export function Favorites() {
     element.scrollLeft += event.deltaY;
   };
 
-  const setBadgeOption = (categoryTab: FavoritesCategoryTabsType) => {
+  const getBadgeOption = (categoryTab: FavoritesCategoryTabsType) => {
     const isSelected = categoryTab.id === selectedCategory;
 
     const options: BadgeProps = {
@@ -65,7 +65,7 @@ export function Favorites() {
         <Header title="관심 목록" />
         <Tabs onWheel={handleWheelEvent}>
           {categoryTabs.map((categoryTab: FavoritesCategoryTabsType, index) => {
-            return <Badge key={index} {...setBadgeOption(categoryTab)} />;
+            return <Badge key={index} {...getBadgeOption(categoryTab)} />;
           })}
         </Tabs>
       </TopBar>

--- a/src/page/Favorites.tsx
+++ b/src/page/Favorites.tsx
@@ -76,7 +76,13 @@ export function Favorites() {
           <>
             {favoritesData?.pages.map(page =>
               page.items.map(item => {
-                return <ProductItem key={item.id} {...item} />;
+                return (
+                  <ProductItem
+                    key={item.id}
+                    {...item}
+                    renderingPosition="favorites"
+                  />
+                );
               })
             )}
             <ObservingTarget ref={observingTargetRef} />

--- a/src/page/ItemDetails.tsx
+++ b/src/page/ItemDetails.tsx
@@ -66,7 +66,7 @@ export function ItemDetails() {
 
   const favoriteMutation = usePatchFavorite();
   const statusMutation = usePatchStatus();
-  const deleteMutation = useDeleteItem();
+  const deleteMutation = useDeleteItem('home');
 
   const plusPageNum = () => {
     setActiveSlidePage(prev => prev + 1);

--- a/src/page/SalesList.tsx
+++ b/src/page/SalesList.tsx
@@ -37,7 +37,7 @@ export function SalesList() {
     }
   }, [inView, hasNextPage, fetchNextPage]);
 
-  const setBadgeOption = (text: string, status: boolean | undefined) => {
+  const getBadgeOption = (text: string, status: boolean | undefined) => {
     const isSelected = isSold === status;
 
     const options: BadgeProps = {
@@ -57,9 +57,9 @@ export function SalesList() {
       <TopBar>
         <Header title="판매 내역" />
         <Tabs>
-          <Badge {...setBadgeOption('전체', undefined)} />
-          <Badge {...setBadgeOption('판매 중', false)} />
-          <Badge {...setBadgeOption('판매 완료', true)} />
+          <Badge {...getBadgeOption('전체', undefined)} />
+          <Badge {...getBadgeOption('판매 중', false)} />
+          <Badge {...getBadgeOption('판매 완료', true)} />
         </Tabs>
       </TopBar>
 

--- a/src/page/SalesList.tsx
+++ b/src/page/SalesList.tsx
@@ -70,7 +70,14 @@ export function SalesList() {
           <>
             {salesListData?.pages.map(page =>
               page.items.map(item => {
-                return <ProductItem key={item.id} {...item} isSeller={true} />;
+                return (
+                  <ProductItem
+                    key={item.id}
+                    {...item}
+                    isSeller={true}
+                    renderingPosition="salesList"
+                  />
+                );
               })
             )}
             <ObservingTarget ref={observingTargetRef} />

--- a/src/page/auth/SignUpPanel.tsx
+++ b/src/page/auth/SignUpPanel.tsx
@@ -132,7 +132,6 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
     }
 
     const res = await singup(formData);
-    console.log(res);
     // TODO : 에러 예외 처리
     if (res.status === 201) {
       showToast({ type: 'success', message: '회원가입 성공!' });
@@ -196,13 +195,7 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
             align="space-between"
           >
             {location.name}
-            <Icon
-              name="pencil"
-              color="accentText"
-              onClick={() => {
-                console.log('삭제할까요?');
-              }}
-            />
+            <Icon name="pencil" color="accentText" />
           </Button>
         ) : (
           <Button

--- a/src/page/home/Home.tsx
+++ b/src/page/home/Home.tsx
@@ -134,7 +134,13 @@ export function Home() {
           <>
             {itemData?.pages.map(page =>
               page.items.map(item => {
-                return <ProductItem key={item.id} {...item} />;
+                return (
+                  <ProductItem
+                    key={item.id}
+                    {...item}
+                    renderingPosition="home"
+                  />
+                );
               })
             )}
             <ObservingTarget ref={observingTargetRef} />

--- a/src/page/productEditor/CategoryContainer.tsx
+++ b/src/page/productEditor/CategoryContainer.tsx
@@ -18,7 +18,7 @@ export function CategoryContainer({
   openModal,
   setCategoryId,
 }: CategoryContainerProps) {
-  const setBadgeOption = (category: FavoritesCategoryTabsType) => {
+  const getBadgeOption = (category: FavoritesCategoryTabsType) => {
     const isSelected = category.id === selectedCategoryId;
     const options: BadgeProps = {
       size: 'M',
@@ -36,7 +36,7 @@ export function CategoryContainer({
     <CategoryWrapper>
       <BadgeWrapper>
         {recommendCategory?.categories.map(category => (
-          <Badge key={category.id} {...setBadgeOption(category)} />
+          <Badge key={category.id} {...getBadgeOption(category)} />
         ))}
       </BadgeWrapper>
       <Button style={{ padding: 0 }} styledType="text" onClick={openModal}>

--- a/src/page/productEditor/ProductEditorPanel.tsx
+++ b/src/page/productEditor/ProductEditorPanel.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { addItems, editItems } from '../../api/fetchers/itemFetcher';
 import {
@@ -30,6 +31,7 @@ type CategoryItem = {
 };
 
 export function ProductEditorPanel() {
+  const navigate = useNavigate();
   const { screenWidth } = useScreenConfigStore();
   const { isOpen, productId, editorMode, productData, closePanel } =
     useProductEditorStore(state => ({
@@ -289,15 +291,15 @@ export function ProductEditorPanel() {
       const res = await editItems(formData, productId!);
 
       if (res.status === 201) {
-        // 해당 상품 상세 페이지로 이동
         onClosePanel();
+        navigate(`/items/${productId}`);
       }
     } else {
       const res = await addItems(formData);
 
       if (res.status === 201) {
-        // 해당 상품 상세 페이지로 이동
         onClosePanel();
+        navigate(`/items/${res.data.itemId}`);
       }
     }
   };

--- a/src/page/productEditor/ProductEditorPanel.tsx
+++ b/src/page/productEditor/ProductEditorPanel.tsx
@@ -147,7 +147,7 @@ export function ProductEditorPanel() {
         : title.value !== productData?.title;
 
     const handler = setTimeout(() => {
-      if (changedTitle) {
+      if (changedTitle && title.value !== '') {
         refetch();
       }
     }, 400);

--- a/src/page/productEditor/ProductEditorPanel.tsx
+++ b/src/page/productEditor/ProductEditorPanel.tsx
@@ -42,8 +42,6 @@ export function ProductEditorPanel() {
 
   const { data: userLocationData } = useGetUserLocation();
   const resetRecommendCategory = useResetRecommendCategory();
-  const { data: recommendCategoryData, refetch } =
-    useGetRecommendCategoryData();
 
   const isEdit = editorMode === 'edit';
   const isError = isEdit && (!productData || !productId);
@@ -79,6 +77,10 @@ export function ProductEditorPanel() {
   const title = useInput(isEdit ? productData!.title : '');
   const price = useInput(isEdit ? productData!.price : '');
   const content = useInput(isEdit ? productData!.content : '');
+
+  const { data: recommendCategoryData, refetch } = useGetRecommendCategoryData(
+    title.value ?? ''
+  );
 
   const selectedLocationData = locationData?.filter(
     data => data.isSelected === true


### PR DESCRIPTION
## Description
- 카테고리 추천 목록 불러오는 api 변경된 점에 맞게 수정
 - productItem에 아이템 상태 변경 로직 추가하기
 - 불필요한 console.log/주석 제거하기
- 남세/리뷰어 피드백 반영하기
  - set과 get 명칭 실수
- 상품 등록/수정 후 해당 상품 상세페이지로 이동 기능 추가

## Key changes
- useItemQuery.ts에 `useDeleteItem` 수정, `usePatchItemStatus` 추가 되었습니다.
  - `useDeleteItem`, `usePatchItemStatus` 모두 refetchTarget을 받습니다.
  - 해당 target은 어디서 해당 api가 호출되었는지 여부에 따라서 invalidateQueries로 refetch되는 query key가 달라집니다.
  - ex) 판매 내역에서 item을 삭제 했다면 판매 내역의 query key인 `SALES_LIST_QUERY_KEY`에 캐싱된 값을 refetch 해야 합니다.
    - 상태 수정도 같습니다.
  - 기존에는 이런 내용이 없어 추가 했습니다.

## To reviewers
- `useDeleteItem`는 상세 페이지에서도 같이 사용하는데 우선 `home`으로 디폴트 값 지정해 놓았습니다.
  -  한번 확인하시고 문제 있으시면 수정 해 주세요.
## Issue
