### PR TITLE
드롭다운 아래 공간에 따라 열릴 방향 결정하는 기능 추가

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { ProductEditorPanel } from '../page/productEditor/ProductEditorPanel';
@@ -9,9 +10,28 @@ import { ToastContainer } from './toast/ToastContainer';
 export function Layout() {
   const { screenWidth, screenHeight } = useScreenConfigStore();
   const isOpenEditor = useProductEditorStore(state => state.isOpen);
+  const layoutRef = useRef<HTMLDivElement>(null);
+  const setScreenRect = useScreenConfigStore(state => state.setScreenRect);
+
+  useEffect(() => {
+    const updateScreenRect = () => {
+      if (layoutRef.current) {
+        const layoutRect = layoutRef.current.getBoundingClientRect();
+        setScreenRect(layoutRect);
+      }
+    };
+
+    updateScreenRect();
+
+    window.addEventListener('resize', updateScreenRect);
+
+    return () => {
+      window.removeEventListener('resize', updateScreenRect);
+    };
+  }, [setScreenRect]);
 
   return (
-    <Wrapper $width={screenWidth} $height={screenHeight}>
+    <Wrapper ref={layoutRef} $width={screenWidth} $height={screenHeight}>
       <Outlet />
       <Footer />
       <ToastContainer />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -15,10 +15,10 @@ export function Layout() {
 
   useEffect(() => {
     const updateScreenRect = () => {
-      if (layoutRef.current) {
-        const layoutRect = layoutRef.current.getBoundingClientRect();
-        setScreenRect(layoutRect);
-      }
+      if (!layoutRef.current) return;
+
+      const layoutRect = layoutRef.current.getBoundingClientRect();
+      setScreenRect(layoutRect);
     };
 
     updateScreenRect();

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
-import { MouseEvent, ReactNode, useEffect, useState } from 'react';
+import { MouseEvent, ReactNode, useEffect, useRef, useState } from 'react';
 import { css, styled } from 'styled-components';
 import { useScrollLock } from '../../hooks/useScrollLock';
+import { useScreenConfigStore } from '../../stores/useScreenConfigStore';
 import { Button } from '../button/Button';
 import { Icon } from '../icon/Icon';
 import { IconsType } from '../icon/icons';
@@ -19,7 +20,10 @@ export function Dropdown({
   align = 'left',
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [direction, setDirection] = useState<'up' | 'down'>('down');
   const [lockScroll, unlockScroll] = useScrollLock('home--body__items');
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const screenRect = useScreenConfigStore(state => state.screenRect);
 
   useEffect(() => {
     if (isOpen) {
@@ -32,6 +36,9 @@ export function Dropdown({
 
   const onToggle = (event: MouseEvent) => {
     event.stopPropagation();
+    if (!isOpen) {
+      chooseDirection();
+    }
     setIsOpen(!isOpen);
   };
 
@@ -41,14 +48,26 @@ export function Dropdown({
     setIsOpen(false);
   };
 
+  const chooseDirection = () => {
+    if (dropdownRef.current && screenRect) {
+      const { bottom } = dropdownRef.current.getBoundingClientRect();
+
+      if (screenRect.bottom - 64 < bottom + 230) {
+        setDirection('up');
+        return;
+      }
+      setDirection('down');
+    }
+  };
+
   return (
-    <div>
+    <div ref={dropdownRef}>
       <DropdownButton styledType="text" onClick={onToggle} $isOpen={isOpen}>
         {btnText && <Text>{btnText}</Text>}
         <Icon name={iconName} color="neutralTextStrong" />
       </DropdownButton>
       {isOpen && (
-        <Container $isOpen={isOpen} $align={align}>
+        <Container $isOpen={isOpen} $align={align} $direction={direction}>
           <Menus onClick={onClose}>{children}</Menus>
         </Container>
       )}
@@ -85,10 +104,12 @@ const Text = styled.span`
 const Container = styled.div<{
   $isOpen: boolean;
   $align: string;
+  $direction: string;
 }>`
   border-radius: 12px;
   position: absolute;
   right: ${({ $align }) => ($align === 'right' ? '8px' : 'auto')};
+  bottom: ${({ $direction }) => ($direction === 'up' ? '40px' : 'auto')};
   z-index: 10;
   background-color: ${({ theme }) => theme.color.neutralBackground};
 `;

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -95,7 +95,7 @@ const Container = styled.div<{
   border-radius: 12px;
   position: absolute;
   right: ${({ $align }) => ($align === 'right' ? '8px' : 'auto')};
-  bottom: ${({ $direction }) => ($direction === 'up' ? '40px' : 'auto')};
+  bottom: ${({ $direction }) => ($direction === 'up' ? '50px' : 'auto')};
   z-index: 10;
   background-color: ${({ theme }) => theme.color.neutralBackground};
 `;

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
-import { MouseEvent, ReactNode, useEffect, useRef, useState } from 'react';
+import { MouseEvent, ReactNode, useEffect, useState } from 'react';
 import { css, styled } from 'styled-components';
+import { useGetDropdownDirection } from '../../hooks/useGetDropdownDirection';
 import { useScrollLock } from '../../hooks/useScrollLock';
-import { useScreenConfigStore } from '../../stores/useScreenConfigStore';
 import { Button } from '../button/Button';
 import { Icon } from '../icon/Icon';
 import { IconsType } from '../icon/icons';
@@ -20,10 +20,8 @@ export function Dropdown({
   align = 'left',
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [direction, setDirection] = useState<'up' | 'down'>('down');
   const [lockScroll, unlockScroll] = useScrollLock('home--body__items');
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const screenRect = useScreenConfigStore(state => state.screenRect);
+  const { dropdownRef, direction, getDirection } = useGetDropdownDirection();
 
   useEffect(() => {
     if (isOpen) {
@@ -37,7 +35,7 @@ export function Dropdown({
   const onToggle = (event: MouseEvent) => {
     event.stopPropagation();
     if (!isOpen) {
-      chooseDirection();
+      getDirection();
     }
     setIsOpen(!isOpen);
   };
@@ -46,18 +44,6 @@ export function Dropdown({
     event.stopPropagation();
     unlockScroll();
     setIsOpen(false);
-  };
-
-  const chooseDirection = () => {
-    if (dropdownRef.current && screenRect) {
-      const { bottom } = dropdownRef.current.getBoundingClientRect();
-
-      if (screenRect.bottom - 64 < bottom + 230) {
-        setDirection('up');
-        return;
-      }
-      setDirection('down');
-    }
   };
 
   return (

--- a/src/components/locations/SignUpLocationModal.tsx
+++ b/src/components/locations/SignUpLocationModal.tsx
@@ -7,13 +7,13 @@ import { AddLocation } from './AddLocation';
 type LocationModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  setSignUpLocation: (locationId: number, locationName: string) => void;
+  onSetSignUpLocation: (locationId: number, locationName: string) => void;
 };
 
 export function SignUpLocationModal({
   isOpen,
   onClose,
-  setSignUpLocation,
+  onSetSignUpLocation,
 }: LocationModalProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -24,7 +24,7 @@ export function SignUpLocationModal({
         </Button>
       </Header>
       <Body>
-        <AddLocation clickLocationItem={setSignUpLocation} />
+        <AddLocation clickLocationItem={onSetSignUpLocation} />
       </Body>
     </Modal>
   );

--- a/src/hooks/useGetDropdownDirection.ts
+++ b/src/hooks/useGetDropdownDirection.ts
@@ -1,8 +1,8 @@
 import { useState, useRef } from 'react';
 import { useScreenConfigStore } from '../stores/useScreenConfigStore';
 
-const FooterHeight = 64;
-const DropdownMaxHeight = 230;
+const FOOTER_HEIGHT = 64;
+const DROPDOWN_MAX_HEIGHT = 230;
 
 export const useGetDropdownDirection = () => {
   const [direction, setDirection] = useState<'up' | 'down'>('down');
@@ -16,8 +16,8 @@ export const useGetDropdownDirection = () => {
       dropdownRef.current.getBoundingClientRect();
 
     if (
-      screenRect.bottom - FooterHeight <
-      dropdownRectBottom + DropdownMaxHeight
+      screenRect.bottom - FOOTER_HEIGHT <
+      dropdownRectBottom + DROPDOWN_MAX_HEIGHT
     ) {
       setDirection('up');
       return;

--- a/src/hooks/useGetDropdownDirection.ts
+++ b/src/hooks/useGetDropdownDirection.ts
@@ -1,0 +1,29 @@
+import { useState, useRef } from 'react';
+import { useScreenConfigStore } from '../stores/useScreenConfigStore';
+
+const FooterHeight = 64;
+const DropdownMaxHeight = 230;
+
+export const useGetDropdownDirection = () => {
+  const [direction, setDirection] = useState<'up' | 'down'>('down');
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const screenRect = useScreenConfigStore(state => state.screenRect);
+
+  const getDirection = () => {
+    if (!dropdownRef.current || !screenRect) return;
+
+    const { bottom: dropdownRectBottom } =
+      dropdownRef.current.getBoundingClientRect();
+
+    if (
+      screenRect.bottom - FooterHeight <
+      dropdownRectBottom + DropdownMaxHeight
+    ) {
+      setDirection('up');
+      return;
+    }
+    setDirection('down');
+  };
+
+  return { dropdownRef, direction, getDirection };
+};

--- a/src/page/ItemDetails.tsx
+++ b/src/page/ItemDetails.tsx
@@ -50,19 +50,12 @@ export function ItemDetails() {
 
   useEffect(() => {
     const isMobile = /Mobile|Android/i.test(navigator.userAgent);
+    const eventName = isMobile ? 'touchmove' : 'wheel';
 
-    if (isMobile) {
-      window.addEventListener('touchmove', onScroll);
-      return;
-    }
-    window.addEventListener('wheel', onScroll);
+    window.addEventListener(eventName, onScroll);
 
     return () => {
-      if (isMobile) {
-        window.removeEventListener('touchmove', onScroll);
-        return;
-      }
-      window.removeEventListener('wheel', onScroll);
+      window.removeEventListener(eventName, onScroll);
     };
   }, []);
 

--- a/src/page/auth/SignUpPanel.tsx
+++ b/src/page/auth/SignUpPanel.tsx
@@ -139,7 +139,7 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
     }
   };
 
-  const setSignUpLocation = (locationId: number, locationName: string) => {
+  const onSetSignUpLocation = (locationId: number, locationName: string) => {
     setLocation({ id: locationId, name: locationName });
     setIsModalOpen(false);
   };
@@ -213,7 +213,7 @@ export function SignUpPanel({ closePanel }: SignUpPanelProps) {
         <SignUpLocationModal
           isOpen={isModalOpen}
           onClose={closeModal}
-          setSignUpLocation={setSignUpLocation}
+          onSetSignUpLocation={onSetSignUpLocation}
         />
       )}
     </Div>

--- a/src/page/productEditor/ProductEditorPanel.tsx
+++ b/src/page/productEditor/ProductEditorPanel.tsx
@@ -466,8 +466,4 @@ const Footer = styled.div`
   background: ${({ theme }) => theme.color.neutralBackgroundWeak};
   color: ${({ theme }) => theme.color.neutralTextStrong};
   font: ${({ theme }) => theme.font.availableDefault16};
-
-  & div {
-    bottom: 65px;
-  }
 `;

--- a/src/stores/useScreenConfigStore.ts
+++ b/src/stores/useScreenConfigStore.ts
@@ -6,12 +6,18 @@ const BASE_HEIGHT = 852;
 type screenConfigState = {
   screenWidth: number;
   screenHeight: number;
+  screenRect: DOMRect | null;
+  setScreenRect: (screenRect: DOMRect) => void;
   updateConfig: () => void;
 };
 
 export const useScreenConfigStore = create<screenConfigState>(set => ({
   screenWidth: BASE_WIDTH,
   screenHeight: BASE_HEIGHT,
+  screenRect: null,
+  setScreenRect: (screenRect: DOMRect) => {
+    set(() => ({ screenRect }));
+  },
   updateConfig: () => {
     const userAgent = navigator.userAgent;
     const isMobile =


### PR DESCRIPTION
## Description
- 드롭다운이 열리는 위치에 따라 방향이 바뀌는 기능을 추가했습니다.

## Key changes
https://github.com/max2023-4th-project-01/FE-Cokkiri-Market/assets/76121068/c27521cc-42dd-4e98-a6e0-68478b753110

- 리뷰어가 피드백으로 알려주셨던 `getBoundingClientRect()` 메서드를 사용해서 로직을 구상했습니다.
- 저희 앱 구조상 브라우저 화면 전체를 쓰는게 아니라 화면 크기나 디바이스에 따라 Layout이 변해서 드롭다운의 DOMRect 값을 비교할 대상을 찾는 것이 어려웠는데요. 여러 방법을 시도하다가 이를 해결하기 위해 `screenRect` 라는 상태를 기존 `useScreenConfigureStore`에 추가했습니다. 여기에는 저희 Layout의 DOMRect 객체를 저장합니다.
- `Layout` 컴포넌트에 useEffect 내부에서 처음 마운트 될 때와 resize 이벤트가 발생할 때 screenRect를 set 해주고 있습니다.
- useGetDropdownDirection 이라는 조금 긴 이름의 커스텀훅을 추가하였습니다. 원래는 그냥 `Dropdown` 컴포넌트 내부에 로직이 있었는데 커스텀훅으로 따로 분리해두면 좋을 것 같더라구요.
- Dropdown의 경우 따로 DOMRect를 구해서 커스텀 훅 내부에서 screenRect의 bottom 값과 dropdownRect의 bottom 값을 비교해서 사이에 드롭다운 최대높이만큼의 여유 공간이 위로 열리도록 했습니다. (어차피 저희 앱에서는 드롭다운이 가장 긴게 4개로 한정되어 있고, ProductItem의 더보기에서 열리는 드롭다운만 잘리는 것 같아서 이렇게 했습니다.)

## To reviewers

## Issue
- #70 